### PR TITLE
Fix #15: Add due date field to todos

### DIFF
--- a/projects/todo-list/public/index.html
+++ b/projects/todo-list/public/index.html
@@ -187,7 +187,7 @@
 
     li {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       gap: 12px;
       padding: 14px 16px;
       background: var(--bg-card);
@@ -221,6 +221,7 @@
     .checkbox {
       width: 22px;
       height: 22px;
+      margin-top: 1px;
       border: 2px solid var(--border);
       border-radius: 6px;
       cursor: pointer;
@@ -302,6 +303,7 @@
       font-size: 16px;
       cursor: pointer;
       padding: 4px 6px;
+      margin-top: -1px;
       border-radius: 6px;
       display: flex;
       align-items: center;
@@ -398,6 +400,118 @@
 
       .stats { font-size: 12px; }
     }
+
+    /* Due date styles */
+    .todo-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .due-date {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 4px;
+    }
+
+    .due-date svg {
+      width: 12px;
+      height: 12px;
+      stroke: currentColor;
+      fill: none;
+      stroke-width: 2;
+      flex-shrink: 0;
+    }
+
+    .due-date.overdue {
+      color: var(--delete-color);
+      font-weight: 600;
+    }
+
+    .due-date.due-today {
+      color: #f59e0b;
+      font-weight: 600;
+    }
+
+    li.overdue {
+      border-color: rgba(239, 68, 68, 0.3);
+    }
+
+    li.overdue:not(.done) {
+      background: rgba(239, 68, 68, 0.04);
+    }
+
+    [data-theme="dark"] li.overdue:not(.done) {
+      background: rgba(239, 68, 68, 0.08);
+    }
+
+    li.done .due-date {
+      color: var(--text-muted);
+      font-weight: 400;
+    }
+
+    /* Due date input */
+    .due-input {
+      flex: 0 0 auto;
+      padding: 14px 12px;
+      border: 2px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 14px;
+      font-family: inherit;
+      background: var(--bg-card);
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color var(--transition), box-shadow var(--transition);
+    }
+
+    .due-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-glow);
+    }
+
+    /* Inline due date edit */
+    .due-date-edit {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-top: 4px;
+    }
+
+    .due-date-edit input {
+      font-size: 12px;
+      padding: 2px 6px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-input);
+      color: var(--text-primary);
+      font-family: inherit;
+      outline: none;
+    }
+
+    .due-date-edit input:focus {
+      border-color: var(--accent);
+    }
+
+    .due-date-edit button {
+      background: none;
+      border: none;
+      font-size: 12px;
+      cursor: pointer;
+      padding: 2px 4px;
+      border-radius: 4px;
+      color: var(--text-muted);
+    }
+
+    .due-date-edit button:hover {
+      color: var(--delete-color);
+      background: rgba(239, 68, 68, 0.1);
+    }
+
+    li:hover .due-date[style*="opacity:0"] {
+      opacity: 1 !important;
+    }
   </style>
 </head>
 <body>
@@ -411,12 +525,14 @@
     <div class="stats" id="stats"></div>
     <div class="input-area">
       <input id="input" type="text" placeholder="What needs to be done?" autofocus>
+      <input id="due-input" class="due-input" type="date" title="Due date (optional)">
       <button onclick="addTodo()">Add</button>
     </div>
     <div class="filters">
       <button class="filter-btn active" data-filter="all" onclick="setFilter('all')">All</button>
       <button class="filter-btn" data-filter="active" onclick="setFilter('active')">Active</button>
       <button class="filter-btn" data-filter="done" onclick="setFilter('done')">Completed</button>
+      <button class="filter-btn" data-filter="overdue" onclick="setFilter('overdue')">Overdue</button>
     </div>
     <ul id="list"></ul>
   </div>
@@ -466,11 +582,45 @@
       }
     });
 
+    // Due date helpers
+    function getTodayStr() {
+      const d = new Date();
+      return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+    }
+
+    function isOverdue(dueDate) {
+      if (!dueDate) return false;
+      return dueDate < getTodayStr();
+    }
+
+    function isDueToday(dueDate) {
+      if (!dueDate) return false;
+      return dueDate === getTodayStr();
+    }
+
+    function formatDueDate(dueDate) {
+      if (!dueDate) return '';
+      const today = getTodayStr();
+      if (dueDate === today) return 'Today';
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const tomorrowStr = tomorrow.getFullYear() + '-' + String(tomorrow.getMonth() + 1).padStart(2, '0') + '-' + String(tomorrow.getDate()).padStart(2, '0');
+      if (dueDate === tomorrowStr) return 'Tomorrow';
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.getFullYear() + '-' + String(yesterday.getMonth() + 1).padStart(2, '0') + '-' + String(yesterday.getDate()).padStart(2, '0');
+      if (dueDate === yesterdayStr) return 'Yesterday';
+      const parts = dueDate.split('-');
+      const d = new Date(parts[0], parts[1] - 1, parts[2]);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: d.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined });
+    }
+
     // Stats and rendering
     function updateStats() {
       const total = todos.length;
       const done = todos.filter(t => t.done).length;
       const active = total - done;
+      const overdue = todos.filter(t => !t.done && isOverdue(t.due_date)).length;
       const el = document.getElementById('stats');
       if (total === 0) {
         el.innerHTML = '';
@@ -479,13 +629,28 @@
       el.innerHTML = `
         <span><span class="dot dot-active"></span>${active} active</span>
         <span><span class="dot dot-done"></span>${done} completed</span>
+        ${overdue ? `<span><span class="dot" style="background:var(--delete-color)"></span>${overdue} overdue</span>` : ''}
       `;
     }
 
     function getFiltered() {
-      if (currentFilter === 'active') return todos.filter(t => !t.done);
-      if (currentFilter === 'done') return todos.filter(t => t.done);
-      return todos;
+      let result;
+      if (currentFilter === 'active') result = todos.filter(t => !t.done);
+      else if (currentFilter === 'done') result = todos.filter(t => t.done);
+      else if (currentFilter === 'overdue') result = todos.filter(t => !t.done && isOverdue(t.due_date));
+      else result = todos.slice();
+
+      // Sort: overdue first, then due today, then by due date ascending, then items without due date
+      result.sort((a, b) => {
+        const aOverdue = !a.done && isOverdue(a.due_date);
+        const bOverdue = !b.done && isOverdue(b.due_date);
+        if (aOverdue !== bOverdue) return aOverdue ? -1 : 1;
+        if (a.due_date && b.due_date) return a.due_date.localeCompare(b.due_date);
+        if (a.due_date && !b.due_date) return -1;
+        if (!a.due_date && b.due_date) return 1;
+        return 0;
+      });
+      return result;
     }
 
     function render() {
@@ -497,11 +662,12 @@
         const msgs = {
           all: 'No todos yet. Add one above!',
           active: 'No active todos. Great job!',
-          done: 'No completed todos yet.'
+          done: 'No completed todos yet.',
+          overdue: 'No overdue todos. Well done!'
         };
         list.innerHTML = `
           <div class="empty">
-            <div class="empty-icon">${currentFilter === 'active' ? '&#127881;' : '&#128221;'}</div>
+            <div class="empty-icon">${currentFilter === 'active' || currentFilter === 'overdue' ? '&#127881;' : '&#128221;'}</div>
             ${msgs[currentFilter]}
           </div>`;
         return;
@@ -509,12 +675,28 @@
 
       list.innerHTML = filtered.map(t => {
         const i = todos.indexOf(t);
+        const overdue = !t.done && isOverdue(t.due_date);
+        const dueToday = !t.done && isDueToday(t.due_date);
+        const liClass = [t.done ? 'done' : '', overdue ? 'overdue' : ''].filter(Boolean).join(' ');
+        const dueDateClass = overdue ? 'due-date overdue' : dueToday ? 'due-date due-today' : 'due-date';
+        const dueDateHtml = t.due_date ? `
+          <div class="${dueDateClass}" onclick="editDueDate(${i}, event)">
+            <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            ${esc(formatDueDate(t.due_date))}
+          </div>` : `
+          <div class="due-date" onclick="editDueDate(${i}, event)" style="opacity:0;cursor:pointer;">
+            <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            Add due date
+          </div>`;
         return `
-        <li class="${t.done ? 'done' : ''}">
+        <li class="${liClass}">
           <div class="checkbox" onclick="toggle(${i})">
             <svg viewBox="0 0 24 24"><polyline points="4 12 10 18 20 6"></polyline></svg>
           </div>
-          <span class="text" ondblclick="startEdit(${i}, event)">${esc(t.text)}</span>
+          <div class="todo-content">
+            <span class="text" ondblclick="startEdit(${i}, event)">${esc(t.text)}</span>
+            ${dueDateHtml}
+          </div>
           <button class="del" onclick="del(${i})" title="Delete" aria-label="Delete todo">&#10005;</button>
         </li>`;
       }).join('');
@@ -529,12 +711,15 @@
     // Actions
     async function addTodo() {
       const input = document.getElementById('input');
+      const dueInput = document.getElementById('due-input');
       const text = input.value.trim();
       if (!text) return;
       input.value = '';
+      const due_date = dueInput.value || null;
+      dueInput.value = '';
       const todo = await api('/todos', {
         method: 'POST',
-        body: JSON.stringify({ text }),
+        body: JSON.stringify({ text, due_date }),
       });
       todos.unshift(todo);
       render();
@@ -618,6 +803,67 @@
         if (e.key === 'Escape') { saved = true; render(); }
       });
       input.addEventListener('blur', saveEdit);
+    }
+
+    // Inline due date editing
+    function editDueDate(i, event) {
+      event.stopPropagation();
+      const filtered = getFiltered();
+      const todoItem = todos[i];
+      const visibleIndex = filtered.indexOf(todoItem);
+      const items = document.querySelectorAll('#list li');
+      if (visibleIndex < 0) return;
+
+      const li = items[visibleIndex];
+      const dueDateEl = li.querySelector('.due-date');
+      if (!dueDateEl) return;
+
+      const container = document.createElement('div');
+      container.className = 'due-date-edit';
+      const dateInput = document.createElement('input');
+      dateInput.type = 'date';
+      dateInput.value = todoItem.due_date || '';
+      container.appendChild(dateInput);
+
+      if (todoItem.due_date) {
+        const clearBtn = document.createElement('button');
+        clearBtn.innerHTML = '&#10005;';
+        clearBtn.title = 'Remove due date';
+        clearBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          saveDueDate(i, '');
+        });
+        container.appendChild(clearBtn);
+      }
+
+      dueDateEl.replaceWith(container);
+      dateInput.focus();
+
+      let saved = false;
+      function saveDueDate(idx, value) {
+        if (saved) return;
+        saved = true;
+        const newDueDate = value !== undefined ? value : dateInput.value;
+        if (newDueDate !== (todos[idx].due_date || '')) {
+          api('/todos/' + todos[idx].id, {
+            method: 'PUT',
+            body: JSON.stringify({ due_date: newDueDate || null }),
+          }).then(updated => {
+            todos[idx] = updated;
+            render();
+          });
+        } else {
+          render();
+        }
+      }
+
+      dateInput.addEventListener('change', () => saveDueDate(i));
+      dateInput.addEventListener('blur', () => {
+        setTimeout(() => { if (!saved) saveDueDate(i); }, 150);
+      });
+      dateInput.addEventListener('keydown', e => {
+        if (e.key === 'Escape') { saved = true; render(); }
+      });
     }
 
     // Keyboard


### PR DESCRIPTION
自动修复 Issue #15

Closes #15

## Changes
- Added `due_date` column to SQLite schema with migration support
- Date picker input for setting due dates when creating todos
- Due date display with human-friendly labels (Today, Tomorrow, etc.)
- Overdue highlighting (red for overdue, amber for due today)
- Inline due date editing with clear button
- "Overdue" filter tab
- Overdue count in stats bar
- Smart sorting (overdue first, then upcoming, then no date)
- docker-compose.yml preserved (no domain/container changes)