### PR TITLE
Fix #20: Add toast error notifications for API failures

### DIFF
--- a/projects/todo-list/public/index.html
+++ b/projects/todo-list/public/index.html
@@ -674,6 +674,59 @@
       box-shadow: var(--shadow-md), 0 0 0 3px var(--accent-glow);
     }
 
+    /* Toast notifications */
+    .toast-container {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 2000;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      pointer-events: none;
+    }
+
+    .toast {
+      padding: 12px 20px;
+      border-radius: var(--radius);
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow-lg);
+      color: var(--text-primary);
+      font-size: 14px;
+      font-family: inherit;
+      pointer-events: auto;
+      animation: toastIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      max-width: 360px;
+      word-break: break-word;
+    }
+
+    .toast.error {
+      border-left: 4px solid var(--delete-color);
+    }
+
+    .toast.removing {
+      animation: toastOut 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    }
+
+    @keyframes toastIn {
+      from {
+        opacity: 0;
+        transform: translateX(40px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0);
+      }
+    }
+
+    @keyframes toastOut {
+      to {
+        opacity: 0;
+        transform: translateX(40px);
+      }
+    }
+
     /* Responsive */
     @media (max-width: 480px) {
       body { padding: 24px 12px 60px; }
@@ -730,6 +783,9 @@
     <ul id="list"></ul>
   </div>
 
+  <!-- Toast notifications -->
+  <div class="toast-container" id="toast-container"></div>
+
   <!-- Help modal -->
   <div class="modal-overlay" id="help-modal">
     <div class="modal">
@@ -778,6 +834,19 @@
     let currentPriorityFilter = 'all';
     let openDropdownIndex = null;
 
+    // Toast notifications
+    function showToast(message, type = 'error') {
+      const container = document.getElementById('toast-container');
+      const toast = document.createElement('div');
+      toast.className = `toast ${type}`;
+      toast.textContent = message;
+      container.appendChild(toast);
+      setTimeout(() => {
+        toast.classList.add('removing');
+        setTimeout(() => toast.remove(), 300);
+      }, 4000);
+    }
+
     // API helpers
     async function api(path, options = {}) {
       const res = await fetch('/api' + path, {
@@ -785,12 +854,21 @@
         ...options,
       });
       if (res.status === 204) return null;
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Request failed (${res.status})`);
+      }
       return res.json();
     }
 
     async function loadTodos() {
-      todos = await api('/todos');
-      render();
+      try {
+        todos = await api('/todos');
+        render();
+      } catch (err) {
+        console.error('Failed to load todos:', err);
+        showToast('Failed to load todos. Please refresh the page.');
+      }
     }
 
     // Theme management (stays in localStorage - per-browser preference)
@@ -890,22 +968,33 @@
       const text = input.value.trim();
       if (!text) return;
       input.value = '';
-      const todo = await api('/todos', {
-        method: 'POST',
-        body: JSON.stringify({ text }),
-      });
-      todos.unshift(todo);
-      render();
+      try {
+        const todo = await api('/todos', {
+          method: 'POST',
+          body: JSON.stringify({ text }),
+        });
+        todos.unshift(todo);
+        render();
+      } catch (err) {
+        console.error('Failed to add todo:', err);
+        showToast('Failed to add todo. Try again.');
+        input.value = text;
+      }
     }
 
     async function toggle(i) {
       const todo = todos[i];
-      const updated = await api('/todos/' + todo.id, {
-        method: 'PUT',
-        body: JSON.stringify({ done: !todo.done }),
-      });
-      todos[i] = updated;
-      render();
+      try {
+        const updated = await api('/todos/' + todo.id, {
+          method: 'PUT',
+          body: JSON.stringify({ done: !todo.done }),
+        });
+        todos[i] = updated;
+        render();
+      } catch (err) {
+        console.error('Failed to update todo:', err);
+        showToast('Failed to update todo. Try again.');
+      }
     }
 
     async function del(i) {
@@ -915,9 +1004,15 @@
       const items = document.querySelectorAll('#list li');
 
       async function doDelete() {
-        await api('/todos/' + todo.id, { method: 'DELETE' });
-        todos.splice(i, 1);
-        render();
+        try {
+          await api('/todos/' + todo.id, { method: 'DELETE' });
+          todos.splice(i, 1);
+          render();
+        } catch (err) {
+          console.error('Failed to delete todo:', err);
+          showToast('Failed to delete todo. Try again.');
+          render();
+        }
       }
 
       if (visibleIndex >= 0 && items[visibleIndex]) {
@@ -969,13 +1064,20 @@
 
     async function setPriority(i, priority) {
       const todo = todos[i];
-      const updated = await api('/todos/' + todo.id, {
-        method: 'PUT',
-        body: JSON.stringify({ priority }),
-      });
-      todos[i] = updated;
-      openDropdownIndex = null;
-      render();
+      try {
+        const updated = await api('/todos/' + todo.id, {
+          method: 'PUT',
+          body: JSON.stringify({ priority }),
+        });
+        todos[i] = updated;
+        openDropdownIndex = null;
+        render();
+      } catch (err) {
+        console.error('Failed to update priority:', err);
+        showToast('Failed to update priority. Try again.');
+        openDropdownIndex = null;
+        render();
+      }
     }
 
     // Close dropdown when clicking outside
@@ -1011,11 +1113,16 @@
         saved = true;
         const newText = input.value.trim();
         if (newText && newText !== todos[i].text) {
-          const updated = await api('/todos/' + todos[i].id, {
-            method: 'PUT',
-            body: JSON.stringify({ text: newText }),
-          });
-          todos[i] = updated;
+          try {
+            const updated = await api('/todos/' + todos[i].id, {
+              method: 'PUT',
+              body: JSON.stringify({ text: newText }),
+            });
+            todos[i] = updated;
+          } catch (err) {
+            console.error('Failed to save edit:', err);
+            showToast('Failed to save changes. Try again.');
+          }
         }
         render();
       }


### PR DESCRIPTION
## Summary
- Add a toast notification system with slide-in/out animations that auto-dismiss after 4 seconds
- Wrap all 6 API call sites (`loadTodos`, `addTodo`, `toggle`, `del`, `setPriority`, `saveEdit`) in try/catch with user-facing error messages
- Enhance the `api()` helper to throw on non-OK HTTP responses, including server-provided error messages
- Log all errors to the console for debugging
- On `addTodo` failure, restore the input text so users don't lose what they typed

Fixes #20

## Test plan
- [ ] Stop the backend server and verify toast notifications appear when loading, adding, toggling, deleting, editing, or changing priority of todos
- [ ] Verify toast messages auto-disappear after ~4 seconds
- [ ] Verify errors are logged to the browser console
- [ ] Verify the toast styling works in both light and dark themes
- [ ] Verify normal operation still works correctly when the backend is running
- [ ] Verify the add todo input is restored when the API call fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)