### PR TITLE
Sync OpenClaw config (20260219)

### DIFF
--- a/vm/host-services/open-claw/MODELS.md
+++ b/vm/host-services/open-claw/MODELS.md
@@ -21,10 +21,10 @@ OpenClaw Gateway (18789)
 **Fallback chain (as configured):**
 
 ```
-Primary:    litellm/claude-opus-4.6-fast
-Fallback 1: openai-codex/gpt-5.2
-Fallback 2: openai-codex/gpt-5.2-codex
-Fallback 3: openai-codex/gpt-5.3-codex
+Primary:    litellm/github-copilot/claude-opus-4.6-fast
+Fallback 1: litellm/github-copilot/claude-sonnet-4.5
+Fallback 2: openai-codex/gpt-5.3-codex
+Fallback 3: openai-codex/gpt-5.2-codex
 ```
 
 ## Provider Configuration
@@ -43,7 +43,7 @@ Connects to the LiteLLM proxy using the OpenAI-completions API format.
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-4.6-fast",
+            "id": "github-copilot/claude-opus-4.6-fast",
             "name": "Claude Opus 4.6 Fast",
             "reasoning": true,
             "input": ["text", "image"],
@@ -51,7 +51,7 @@ Connects to the LiteLLM proxy using the OpenAI-completions API format.
             "maxTokens": 64000
           },
           {
-            "id": "claude-sonnet-4.5",
+            "id": "github-copilot/claude-sonnet-4.5",
             "name": "Claude Sonnet 4.5",
             "reasoning": true,
             "input": ["text", "image"],
@@ -69,8 +69,8 @@ Connects to the LiteLLM proxy using the OpenAI-completions API format.
 
 | Model Ref | Context | Input | Role |
 |-----------|---------|-------|------|
-| `litellm/claude-opus-4.6-fast` | 200k | text+image | Primary |
-| `litellm/claude-sonnet-4.5` | 200k | text+image | Available (not in fallback chain) |
+| `litellm/github-copilot/claude-opus-4.6-fast` | 200k | text+image | Primary |
+| `litellm/github-copilot/claude-sonnet-4.5` | 200k | text+image | Fallback 1 |
 
 ### openai-codex (Fallback)
 
@@ -81,17 +81,7 @@ Direct connection to OpenAI API using OAuth authentication via ChatGPT Plus acco
   "providers": {
     "openai-codex": {
       "baseUrl": "https://api.openai.com/v1",
-      "api": "openai-completions",
-      "models": [
-        {
-          "id": "gpt-5.3-codex",
-          "name": "GPT-5.3 Codex",
-          "reasoning": true,
-          "input": ["text", "image"],
-          "contextWindow": 200000,
-          "maxTokens": 16384
-        }
-      ]
+      "api": "openai-completions"
     }
   }
 }
@@ -99,11 +89,12 @@ Direct connection to OpenAI API using OAuth authentication via ChatGPT Plus acco
 
 **Authentication:** OAuth (no API key needed), requires ChatGPT Plus subscription.
 
+Note: The `openai-codex` provider no longer has models defined in the config — it uses dynamically available models from the OpenAI API.
+
 | Model Ref | Context | Role |
 |-----------|---------|------|
-| `openai-codex/gpt-5.2` | — | Fallback 1 |
-| `openai-codex/gpt-5.2-codex` | — | Fallback 2 |
-| `openai-codex/gpt-5.3-codex` | 200k | Fallback 3 |
+| `openai-codex/gpt-5.3-codex` | 200k | Fallback 2 |
+| `openai-codex/gpt-5.2-codex` | — | Fallback 3 |
 
 ## Services
 

--- a/vm/host-services/open-claw/openclaw.example.json
+++ b/vm/host-services/open-claw/openclaw.example.json
@@ -1,5 +1,12 @@
 {
   "_comment": "EXAMPLE CONFIG - For reference only. Actual config is at ~/.openclaw/openclaw.json. Sensitive values use ${ENV_VAR} placeholders.",
+  "browser": {
+    "enabled": true,
+    "executablePath": "/home/jingtao/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome",
+    "headless": true,
+    "noSandbox": true,
+    "defaultProfile": "openclaw"
+  },
   "auth": {
     "profiles": {
       "litellm:default": {
@@ -20,7 +27,7 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-4.6-fast",
+            "id": "github-copilot/claude-opus-4.6-fast",
             "name": "Claude Opus 4.6 Fast",
             "reasoning": true,
             "input": [
@@ -37,7 +44,7 @@
             "maxTokens": 64000
           },
           {
-            "id": "claude-sonnet-4.5",
+            "id": "github-copilot/claude-sonnet-4.5",
             "name": "Claude Sonnet 4.5",
             "reasoning": true,
             "input": [
@@ -54,47 +61,24 @@
             "maxTokens": 64000
           }
         ]
-      },
-      "openai-codex": {
-        "baseUrl": "https://api.openai.com/v1",
-        "api": "openai-completions",
-        "models": [
-          {
-            "id": "gpt-5.3-codex",
-            "name": "GPT-5.3 Codex",
-            "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 200000,
-            "maxTokens": 16384
-          }
-        ]
       }
     }
   },
   "agents": {
     "defaults": {
       "model": {
-        "primary": "litellm/claude-opus-4.6-fast",
+        "primary": "litellm/github-copilot/claude-opus-4.6-fast",
         "fallbacks": [
-          "openai-codex/gpt-5.2",
-          "openai-codex/gpt-5.2-codex",
-          "openai-codex/gpt-5.3-codex"
+          "litellm/github-copilot/claude-sonnet-4.5",
+          "openai-codex/gpt-5.3-codex",
+          "openai-codex/gpt-5.2-codex"
         ]
       },
       "models": {
-        "litellm/claude-opus-4.6-fast": {},
-        "openai-codex/gpt-5.2": {},
-        "openai-codex/gpt-5.2-codex": {},
-        "openai-codex/gpt-5.3-codex": {}
+        "litellm/github-copilot/claude-opus-4.6-fast": {},
+        "litellm/github-copilot/claude-sonnet-4.5": {},
+        "openai-codex/gpt-5.3-codex": {},
+        "openai-codex/gpt-5.2-codex": {}
       },
       "workspace": "/home/jingtao/.openclaw/workspace",
       "compaction": {
@@ -133,6 +117,45 @@
   "session": {
     "dmScope": "per-channel-peer"
   },
+  "hooks": {
+    "enabled": true,
+    "path": "/hooks",
+    "token": "${OPENCLAW_GATEWAY_TOKEN}"
+  },
+  "channels": {
+    "discord": {
+      "name": "Discord",
+      "enabled": true,
+      "token": "${S_DISCORD_BOT_TOKEN}",
+      "groupPolicy": "allowlist",
+      "dm": {
+        "policy": "pairing",
+        "allowFrom": [
+          "1471352977691250891"
+        ]
+      },
+      "guilds": {
+        "1471415768955490418": {
+          "requireMention": false,
+          "users": [
+            "1471352977691250891",
+            "1471678943999426643",
+            "1471680872607518932"
+          ],
+          "channels": {
+            "*": {
+              "enabled": true
+            },
+            "1471752874982768794": {
+              "enabled": true,
+              "requireMention": true
+            }
+          }
+        }
+      },
+      "allowBots": true
+    }
+  },
   "gateway": {
     "port": 18789,
     "mode": "local",
@@ -164,19 +187,6 @@
       },
       "discord": {
         "enabled": true
-      }
-    }
-  },
-  "channels": {
-    "discord": {
-      "name": "Discord",
-      "enabled": true,
-      "token": "${S_DISCORD_BOT_TOKEN}",
-      "groupPolicy": "open",
-      "guilds": {
-        "*": {
-          "requireMention": false
-        }
       }
     }
   }


### PR DESCRIPTION
Automated daily sync of OpenClaw configuration and documentation updates.

### Changes
- **Browser config added** — Playwright-based headless Chromium with `openclaw` profile
- **Model IDs updated** — Now prefixed with `github-copilot/` (e.g., `github-copilot/claude-opus-4.6-fast`)
- **Fallback chain updated** — Claude Sonnet 4.5 added as first fallback; `openai-codex` profile removed from auth
- **Hooks section added** — Webhook hooks enabled for external process notifications
- **Discord config expanded** — `groupPolicy: allowlist` with per-guild/channel/user access control (was `open` with wildcard)
- **Documentation updated** — MODELS.md, CONFIGURATION.md reflect new config structure