### PR TITLE
Add share-board service using pre-built registry image

### DIFF
--- a/vm/docker-services/share-board-service/docker-compose.yml
+++ b/vm/docker-services/share-board-service/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  share-board:
+    image: registry.us.jingtao.fun/share-board:latest
+    environment:
+      - VIRTUAL_HOST=board.${S_DOMAIN}
+      - VIRTUAL_PORT=3000
+      - LETSENCRYPT_HOST=board.${S_DOMAIN}
+      - LETSENCRYPT_EMAIL=${S_EMAIL}
+      - BASE_URL=https://board.${S_DOMAIN}
+      - DATA_DIR=/app/data
+    volumes:
+      - ${S_CONTAINER_FOLDER_STATIC}/share-board:/app/data
+    restart: always
+    container_name: share-board


### PR DESCRIPTION
Adds a docker-compose service definition under `vm/docker-services/share-board-service/` that pulls the pre-built image from `registry-self-host.us.jingtao.fun/share-board:latest` instead of building from source.

For deployments on other machines that pull from the private registry.

**Note:** The registry is currently returning 503, so the image push is pending. The image has been built and tagged locally — will push once the registry is back up.