### PR TITLE
feat: add image-hosting service (img.ai.jingtao.fun)

### DIFF
--- a/vm/docker-services/image-hosting/docker-compose.yml
+++ b/vm/docker-services/image-hosting/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  image-hosting:
+    image: nginx:alpine
+    environment:
+      - VIRTUAL_HOST=img.${S_DOMAIN}
+      - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=img.${S_DOMAIN}
+      - LETSENCRYPT_EMAIL=${S_EMAIL}
+    volumes:
+      - ${S_CONTAINER_FOLDER_STATIC}/image-hosting:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: always
+    container_name: image-hosting
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true

--- a/vm/docker-services/image-hosting/nginx.conf
+++ b/vm/docker-services/image-hosting/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+
+    # Disable directory listing
+    autoindex off;
+
+    # Only serve image files
+    location / {
+        # Block access to root
+        return 403;
+    }
+
+    location ~* \.(png|jpg|jpeg|gif|webp|svg|ico)$ {
+        expires 180d;
+        add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
## What
Simple nginx-based static image hosting service.

## Details
- Domain: `img.ai.jingtao.fun`
- Serves only image files (png/jpg/gif/webp/svg/ico)
- 180-day cache with immutable header
- No directory listing, root returns 403
- HTTPS via Let's Encrypt (auto-cert through nginx-proxy)
- Storage: `/data_static/image-hosting/`

## Use Case
Host generated images (AI image generation, wedding assets, etc.) with shareable URLs.

**Already deployed and running.**