### PR TITLE
feat: Listen English UI improvements - overlay, numpad, stop, edit tracking

### DIFF
--- a/projects/listen-english/css/style.css
+++ b/projects/listen-english/css/style.css
@@ -204,30 +204,24 @@ body {
   width: 80px;
 }
 
-/* Play Section */
+/* Play Section — Start button */
 .play-section {
   text-align: center;
-}
-
-.play-controls {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 20px;
+  padding: 32px 20px;
 }
 
 .play-btn {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 36px;
+  border-radius: 40px;
   border: none;
   background: var(--color-primary);
   color: white;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-size: 1.1rem;
+  font-weight: 700;
   transition: all 0.2s;
   box-shadow: var(--shadow-lg);
 }
@@ -241,39 +235,69 @@ body {
   transform: scale(0.98);
 }
 
-.play-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
+.play-label {
+  font-size: 1.1rem;
 }
 
-.stop-btn {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  border: none;
-  background: var(--color-wrong);
-  color: white;
-  cursor: pointer;
+/* Training Overlay */
+.training-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: var(--color-bg);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
-  box-shadow: var(--shadow-lg);
+  padding: 16px;
 }
 
-.stop-btn:hover {
-  background: #dc2626;
-  transform: scale(1.05);
+.training-overlay.hidden {
+  display: none;
 }
 
-.stop-btn:active {
-  transform: scale(0.98);
+.training-card {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.replay-btn {
-  width: 44px;
-  height: 44px;
+/* Top bar */
+.training-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 4px;
+}
+
+.training-stats {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.tstats.correct { color: var(--color-correct); }
+.tstats-sep { color: var(--color-text-secondary); font-size: 1rem; }
+.tstats-pct {
+  margin-left: 8px;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.training-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.replay-btn-sm,
+.stop-btn-sm {
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   border: 2px solid var(--color-border);
   background: var(--color-surface);
@@ -285,32 +309,81 @@ body {
   transition: all 0.2s;
 }
 
-.replay-btn:hover:not(:disabled) {
+.replay-btn-sm:hover:not(:disabled) {
   border-color: var(--color-primary);
   color: var(--color-primary);
 }
 
-.replay-btn:disabled {
+.replay-btn-sm:disabled {
   opacity: 0.3;
   cursor: not-allowed;
 }
 
-/* Answer Area */
-.answer-area {
-  max-width: 320px;
-  margin: 0 auto;
+.stop-btn-sm {
+  border-color: var(--color-wrong);
+  color: var(--color-wrong);
+}
+
+.stop-btn-sm:hover {
+  background: var(--color-wrong);
+  color: white;
+}
+
+/* Feedback area — single row, fixed height */
+.training-feedback {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feedback-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+}
+
+.training-feedback .feedback {
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  transition: color 0.2s;
+  color: transparent;
+}
+
+.training-feedback .feedback.correct {
+  color: var(--color-correct);
+}
+
+.training-feedback .feedback.wrong {
+  color: var(--color-wrong);
+}
+
+.training-feedback .reaction-time {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+/* Answer display in overlay */
+.training-answer {
+  display: flex;
+  justify-content: center;
 }
 
 .answer-input {
   width: 100%;
+  max-width: 320px;
   padding: 14px 16px;
   border: 2px solid var(--color-border);
   border-radius: var(--radius);
-  font-size: 1.5rem;
+  font-size: 2rem;
   text-align: center;
   outline: none;
   transition: border-color 0.2s;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
+  background: var(--color-surface);
 }
 
 .answer-input:focus {
@@ -332,38 +405,13 @@ body {
   background: var(--color-wrong-bg);
 }
 
-/* Feedback */
-.feedback {
-  margin-top: 12px;
-  padding: 10px 16px;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.3s;
-}
-
+/* Legacy feedback classes kept for JS compat */
 .feedback.correct {
-  background: var(--color-correct-bg);
   color: var(--color-correct);
 }
 
 .feedback.wrong {
-  background: var(--color-wrong-bg);
   color: var(--color-wrong);
-}
-
-.feedback.hidden {
-  display: none;
-}
-
-.reaction-time {
-  margin-top: 8px;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
-}
-
-.reaction-time.hidden {
-  display: none;
 }
 
 /* Stats Grid */
@@ -513,8 +561,9 @@ body {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 8px;
+  width: 100%;
   max-width: 320px;
-  margin: 16px auto 0;
+  margin: 0 auto;
 }
 
 .numpad-btn {
@@ -586,13 +635,8 @@ body {
     justify-content: center;
   }
 
-  .answer-input {
-    font-size: 1.3rem;
-  }
-
   .play-btn {
-    width: 64px;
-    height: 64px;
+    padding: 14px 28px;
   }
 
   .auto-play-config {
@@ -602,5 +646,18 @@ body {
 
   .auto-play-config input {
     width: 100%;
+  }
+
+  .training-overlay {
+    padding: 12px;
+  }
+
+  .answer-input {
+    font-size: 1.6rem;
+  }
+
+  .numpad-btn {
+    padding: 14px 0;
+    font-size: 1.2rem;
   }
 }

--- a/projects/listen-english/index.html
+++ b/projects/listen-english/index.html
@@ -46,30 +46,54 @@
         </div>
       </section>
 
-      <!-- Play Area -->
+      <!-- Start Button -->
       <section class="card play-section">
-        <div class="play-controls">
-          <button id="play-btn" class="play-btn" title="Play number (Space)">
-            <svg viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
-              <path d="M8 5v14l11-7z"/>
-            </svg>
-          </button>
-          <button id="stop-btn" class="stop-btn" title="Stop" style="display:none;">
-            <svg viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
-              <rect x="6" y="6" width="12" height="12" rx="2"/>
-            </svg>
-          </button>
-          <button id="replay-btn" class="replay-btn" title="Replay (R)" disabled>
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
-              <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
-            </svg>
-          </button>
+        <button id="play-btn" class="play-btn" title="Start Practice (Space)">
+          <svg viewBox="0 0 24 24" width="32" height="32" fill="currentColor">
+            <path d="M8 5v14l11-7z"/>
+          </svg>
+          <span class="play-label">Start</span>
+        </button>
+      </section>
+
+    <!-- Training Overlay (fixed fullscreen card) -->
+    <div id="training-overlay" class="training-overlay hidden">
+      <div class="training-card">
+        <!-- Top bar: stats + stop -->
+        <div class="training-top">
+          <div class="training-stats">
+            <span id="overlay-correct" class="tstats correct">0</span>
+            <span class="tstats-sep">/</span>
+            <span id="overlay-total" class="tstats">0</span>
+            <span id="overlay-accuracy" class="tstats-pct">—</span>
+          </div>
+          <div class="training-controls">
+            <button id="replay-btn" class="replay-btn-sm" title="Replay (R)" disabled>
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+              </svg>
+            </button>
+            <button id="stop-btn" class="stop-btn-sm" title="Stop">
+              <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                <rect x="6" y="6" width="12" height="12" rx="2"/>
+              </svg>
+            </button>
+          </div>
         </div>
-        <div class="answer-area">
-          <input type="text" id="answer-input" class="answer-input" placeholder="Type the number you heard..." disabled autocomplete="off" inputmode="none" readonly>
-          <div id="feedback" class="feedback hidden"></div>
-          <div id="reaction-time" class="reaction-time hidden"></div>
+
+        <!-- Feedback area (fixed height, no layout shift) -->
+        <div class="training-feedback">
+          <div class="feedback-row">
+            <span id="feedback" class="feedback">&nbsp;</span>
+            <span id="reaction-time" class="reaction-time">&nbsp;</span>
+          </div>
         </div>
+
+        <!-- Answer display -->
+        <div class="training-answer">
+          <input type="text" id="answer-input" class="answer-input" placeholder="?" disabled autocomplete="off" inputmode="none" readonly>
+        </div>
+
         <!-- Number Pad -->
         <div class="numpad">
           <button class="numpad-btn" data-value="1">1</button>
@@ -85,7 +109,8 @@
           <button class="numpad-btn" data-value="0">0</button>
           <button class="numpad-btn numpad-fn numpad-submit" data-action="submit">OK</button>
         </div>
-      </section>
+      </div>
+    </div>
 
       <!-- Session Statistics -->
       <section class="card stats-section">

--- a/projects/listen-english/js/app.js
+++ b/projects/listen-english/js/app.js
@@ -4,9 +4,9 @@ const App = (() => {
   // State
   let currentNumber = null;
   let isPlaying = false;
-  let isRunning = false; // whether auto-play loop is active
+  let isRunning = false;
   let autoAdvanceTimer = null;
-  let editLog = []; // tracks edits for current question: {action, value, timestamp}
+  let editLog = [];
   let session = {
     total: 0,
     correct: 0,
@@ -36,6 +36,12 @@ const App = (() => {
     els.answerInput = document.getElementById('answer-input');
     els.feedback = document.getElementById('feedback');
     els.reactionTime = document.getElementById('reaction-time');
+    els.overlay = document.getElementById('training-overlay');
+    // Overlay stats
+    els.overlayCorrect = document.getElementById('overlay-correct');
+    els.overlayTotal = document.getElementById('overlay-total');
+    els.overlayAccuracy = document.getElementById('overlay-accuracy');
+    // Main page stats
     els.statTotal = document.getElementById('stat-total');
     els.statCorrect = document.getElementById('stat-correct');
     els.statWrong = document.getElementById('stat-wrong');
@@ -65,8 +71,8 @@ const App = (() => {
   }
 
   function bindEvents() {
-    // Play button
-    els.playBtn.addEventListener('click', playNumber);
+    // Play button — opens overlay and starts
+    els.playBtn.addEventListener('click', startSession);
 
     // Stop button
     els.stopBtn.addEventListener('click', stopSession);
@@ -89,16 +95,18 @@ const App = (() => {
 
     // Keyboard shortcuts
     document.addEventListener('keydown', (e) => {
-      // Don't trigger shortcuts when typing in inputs (except answer-input Enter handled above)
       if (e.target.tagName === 'INPUT' && e.target !== els.answerInput) return;
       if (e.target === els.answerInput && e.key !== ' ') return;
 
       if (e.key === ' ' && e.target !== els.answerInput) {
         e.preventDefault();
-        playNumber();
+        if (isRunning) return;
+        startSession();
       } else if ((e.key === 'r' || e.key === 'R') && e.target !== els.answerInput) {
         e.preventDefault();
         replayNumber();
+      } else if (e.key === 'Escape') {
+        stopSession();
       }
     });
 
@@ -136,7 +144,6 @@ const App = (() => {
         const value = btn.dataset.value;
         const action = btn.dataset.action;
         if (value !== undefined) {
-          // Digit button — append to input
           if (!els.answerInput.disabled) {
             els.answerInput.value += value;
             editLog.push({ action: 'digit', value: els.answerInput.value, ts: Date.now() });
@@ -171,29 +178,43 @@ const App = (() => {
     return Math.floor(Math.random() * (hi - lo + 1)) + lo;
   }
 
+  function startSession() {
+    // Reset session stats
+    session = { total: 0, correct: 0, wrong: 0, streak: 0, reactionTimes: [] };
+    // Show overlay
+    els.overlay.classList.remove('hidden');
+    // Prevent background scroll
+    document.body.style.overflow = 'hidden';
+    updateOverlayStats();
+    // Clear feedback
+    els.feedback.textContent = '\u00A0';
+    els.feedback.className = 'feedback';
+    els.reactionTime.textContent = '\u00A0';
+    // Start first number
+    playNumber();
+  }
+
   async function playNumber() {
     if (isPlaying) return;
     isPlaying = true;
     isRunning = true;
 
-    // Generate new number
     currentNumber = getRandomNumber();
 
-    // Reset UI
+    // Reset input
     els.answerInput.value = '';
-    els.feedback.classList.add('hidden');
-    els.feedback.className = 'feedback hidden';
-    els.reactionTime.classList.add('hidden');
     els.answerInput.disabled = false;
     els.replayBtn.disabled = false;
-    els.playBtn.style.display = 'none';
-    els.stopBtn.style.display = 'flex';
+
+    // Clear feedback text but keep space
+    els.feedback.textContent = '\u00A0';
+    els.feedback.className = 'feedback';
+    els.reactionTime.textContent = '\u00A0';
 
     Timer.reset();
     editLog = [];
 
     try {
-      // Speak the number, start timer when speech ends
       await TTS.speak(currentNumber);
       Timer.start();
     } catch (err) {
@@ -208,32 +229,31 @@ const App = (() => {
     isPlaying = false;
     currentNumber = null;
 
-    // Cancel any pending auto-advance
     if (autoAdvanceTimer) {
       clearTimeout(autoAdvanceTimer);
       autoAdvanceTimer = null;
     }
 
-    // Cancel any in-progress speech
     TTS.cancel && TTS.cancel();
     window.speechSynthesis && window.speechSynthesis.cancel();
-
     Timer.reset();
 
-    // Reset UI
+    // Hide overlay
+    els.overlay.classList.add('hidden');
+    document.body.style.overflow = '';
+
+    // Reset
     els.answerInput.value = '';
     els.answerInput.disabled = true;
-    els.feedback.classList.add('hidden');
-    els.reactionTime.classList.add('hidden');
     els.replayBtn.disabled = true;
-    els.playBtn.style.display = 'flex';
-    els.stopBtn.style.display = 'none';
+
+    // Update main page stats
+    updateStats();
   }
 
   async function replayNumber() {
     if (currentNumber === null || isPlaying) return;
     isPlaying = true;
-    els.playBtn.disabled = true;
 
     Timer.reset();
     editLog = [];
@@ -246,7 +266,6 @@ const App = (() => {
     }
 
     isPlaying = false;
-    els.playBtn.disabled = false;
   }
 
   function submitAnswer() {
@@ -261,7 +280,6 @@ const App = (() => {
     const reactionTimeMs = Timer.stop();
     const correct = userAnswer === currentNumber;
 
-    // Update session stats
     session.total++;
     if (correct) {
       session.correct++;
@@ -274,25 +292,20 @@ const App = (() => {
       session.reactionTimes.push(reactionTimeMs);
     }
 
-    // Save to history
     Storage.addRecord({
       number: currentNumber,
       userAnswer: userAnswer,
       correct: correct,
       reactionTimeMs: reactionTimeMs,
-      edits: editLog.slice(), // copy of edit log
+      edits: editLog.slice(),
     });
 
-    // Show feedback
     showFeedback(correct, currentNumber, reactionTimeMs);
-
-    // Update stats display
+    updateOverlayStats();
     updateStats();
 
-    // Disable input while showing feedback
     els.answerInput.disabled = true;
 
-    // Auto-advance only if session is still running
     if (isRunning) {
       const delay = (parseFloat(els.autoPlayDelay.value) || 1.5) * 1000;
       autoAdvanceTimer = setTimeout(() => {
@@ -305,20 +318,29 @@ const App = (() => {
   }
 
   function showFeedback(correct, number, timeMs) {
-    els.feedback.classList.remove('hidden', 'correct', 'wrong');
+    els.feedback.className = 'feedback';
 
     if (correct) {
       els.feedback.classList.add('correct');
-      els.feedback.textContent = '✅ Correct!';
+      els.feedback.textContent = '✅ Correct';
     } else {
       els.feedback.classList.add('wrong');
-      els.feedback.textContent = `❌ Wrong — the answer was ${number}`;
+      els.feedback.textContent = `❌ ${number}`;
     }
 
-    // Show reaction time
     if (timeMs > 0) {
-      els.reactionTime.classList.remove('hidden');
       els.reactionTime.textContent = `⏱️ ${(timeMs / 1000).toFixed(2)}s`;
+    }
+  }
+
+  function updateOverlayStats() {
+    els.overlayCorrect.textContent = session.correct;
+    els.overlayTotal.textContent = session.total;
+    if (session.total > 0) {
+      els.overlayAccuracy.textContent =
+        Math.round((session.correct / session.total) * 100) + '%';
+    } else {
+      els.overlayAccuracy.textContent = '—';
     }
   }
 
@@ -348,7 +370,6 @@ const App = (() => {
   return { init };
 })();
 
-// Start the app when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
   App.init();
 });


### PR DESCRIPTION
## Changes

- **Training overlay**: Full-screen fixed card when practicing — no scroll jitter, everything pinned
- **Number pad**: On-screen 0-9, backspace, OK buttons — no keyboard popup on mobile
- **Stop button**: Halt auto-play loop, cancel speech, close overlay
- **Compact feedback**: Correct/wrong + reaction time on single row
- **Edit tracking**: Records every digit/backspace with timestamps, new "Hesitated Answers" analytics
- **Dockerfile fix**: Remove non-existent assets/ directory

Tested on preview deploy, all working.