### PR TITLE
fix: remove non-existent assets/ dir from listen-english Dockerfile

### DIFF
--- a/projects/listen-english/Dockerfile
+++ b/projects/listen-english/Dockerfile
@@ -3,6 +3,5 @@ FROM nginx:alpine
 COPY index.html /usr/share/nginx/html/
 COPY css/ /usr/share/nginx/html/css/
 COPY js/ /usr/share/nginx/html/js/
-COPY assets/ /usr/share/nginx/html/assets/
 
 EXPOSE 80


### PR DESCRIPTION
The Dockerfile references `COPY assets/` but no assets/ directory exists, causing CI build failure.

Removes the line to fix the pipeline.