### PR TITLE
Fix #78: Session Viewer: smaller font, markdown rendering, collapsible code blocks

### DIFF
--- a/projects/openclaw-explorer/public/css/session-viewer.css
+++ b/projects/openclaw-explorer/public/css/session-viewer.css
@@ -323,8 +323,8 @@
 
 .sv-event-body {
   padding: 6px 10px;
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 /* User message */
@@ -539,10 +539,87 @@
   word-break: break-word;
 }
 
+/* Markdown-rendered message content */
 .sv-text-content {
-  white-space: pre-wrap;
   word-break: break-word;
 }
+
+.sv-text-content p { margin: 0 0 0.5em; }
+.sv-text-content p:last-child { margin-bottom: 0; }
+.sv-text-content h1, .sv-text-content h2, .sv-text-content h3,
+.sv-text-content h4, .sv-text-content h5, .sv-text-content h6 {
+  margin: 0.6em 0 0.3em;
+  line-height: 1.3;
+}
+.sv-text-content h1 { font-size: 1.3em; }
+.sv-text-content h2 { font-size: 1.15em; }
+.sv-text-content h3 { font-size: 1.05em; }
+.sv-text-content ul, .sv-text-content ol { margin: 0.3em 0; padding-left: 1.5em; }
+.sv-text-content li { margin: 0.15em 0; }
+.sv-text-content a { color: var(--accent); text-decoration: none; }
+.sv-text-content a:hover { text-decoration: underline; }
+.sv-text-content code {
+  background: var(--bg-secondary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+}
+.sv-text-content pre {
+  margin: 0.5em 0;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  overflow: auto;
+  line-height: 1.4;
+}
+.sv-text-content pre code {
+  display: block;
+  padding: 8px 10px;
+  background: none;
+  border-radius: 0;
+  font-size: 11px;
+  white-space: pre;
+  overflow-x: auto;
+}
+.sv-text-content blockquote {
+  margin: 0.4em 0;
+  padding: 2px 10px;
+  border-left: 3px solid var(--border);
+  color: var(--text-secondary);
+}
+.sv-text-content table {
+  border-collapse: collapse;
+  margin: 0.4em 0;
+  font-size: 0.95em;
+}
+.sv-text-content th, .sv-text-content td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+}
+.sv-text-content th { background: var(--bg-secondary); font-weight: 600; }
+
+/* Collapsible code blocks */
+.sv-code-wrapper { position: relative; margin: 0.5em 0; }
+.sv-code-wrapper pre { margin: 0; }
+.sv-code-wrapper.collapsed pre {
+  max-height: calc(10 * 1.4em + 16px); /* ~10 lines */
+  overflow: hidden;
+}
+.sv-code-toggle {
+  display: block;
+  width: 100%;
+  padding: 4px 10px;
+  background: var(--bg-secondary);
+  border: none;
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 6px 6px;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+.sv-code-toggle:hover { color: var(--accent-hover, var(--accent)); background: var(--bg-tertiary); }
 
 .sv-show-more {
   display: inline-block;

--- a/projects/openclaw-explorer/public/pages/session-viewer.html
+++ b/projects/openclaw-explorer/public/pages/session-viewer.html
@@ -6,6 +6,7 @@
 <title>Session Viewer - OpenClaw Explorer</title>
 <link rel="stylesheet" href="../css/style.css">
 <link rel="stylesheet" href="../css/session-viewer.css">
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
 </head>
 <body>
 
@@ -713,7 +714,7 @@
         <span class="sv-event-type">User</span>
         <span class="sv-event-time">${formatTimestamp(getEventTimestamp(evt))}</span>
       </div>
-      <div class="sv-event-body"><div class="sv-text-content">${escapeHtml(text)}</div></div>
+      <div class="sv-event-body"><div class="sv-text-content">${renderMarkdown(text)}</div></div>
     </div>`;
   }
 
@@ -731,7 +732,7 @@
         <span class="sv-event-type">Assistant</span>
         <span class="sv-event-time">${formatTimestamp(getEventTimestamp(evt))}</span>
       </div>
-      <div class="sv-event-body"><div class="sv-text-content">${escapeHtml(text)}</div></div>
+      <div class="sv-event-body"><div class="sv-text-content">${renderMarkdown(text)}</div></div>
     </div>`;
   }
 
@@ -857,6 +858,37 @@
       .replace(/"/g, '&quot;');
   }
 
+  // Markdown rendering with collapsible code blocks
+  const markedInstance = new marked.Marked({
+    breaks: true,
+    gfm: true,
+  });
+
+  function renderMarkdown(text) {
+    if (!text) return '';
+    let html = markedInstance.parse(text);
+    html = wrapCollapsibleCodeBlocks(html);
+    return html;
+  }
+
+  const CODE_LINE_THRESHOLD = 10;
+
+  function wrapCollapsibleCodeBlocks(html) {
+    // Wrap <pre><code>...</code></pre> blocks that exceed the line threshold
+    return html.replace(/<pre><code(?:\s+class="([^"]*)")?>([\s\S]*?)<\/code><\/pre>/g,
+      function(match, langClass, code) {
+        const lineCount = code.split('\n').length;
+        if (lineCount <= CODE_LINE_THRESHOLD) return match;
+        const lang = langClass ? langClass.replace(/^language-/, '') : '';
+        const label = lang ? lang + ' · ' + lineCount + ' lines' : lineCount + ' lines';
+        return '<div class="sv-code-wrapper collapsed">'
+          + '<pre><code' + (langClass ? ' class="' + langClass + '"' : '') + '>' + code + '</code></pre>'
+          + '<button class="sv-code-toggle" data-label-show="Show code (' + label + ')" data-label-hide="Hide code (' + label + ')">Show code (' + label + ')</button>'
+          + '</div>';
+      }
+    );
+  }
+
   // Mobile sidebar toggle
   const sidebarToggleBtn = document.getElementById('sidebarToggle');
   if (sidebarToggleBtn) {
@@ -865,8 +897,19 @@
     });
   }
 
-  // "Show more" and expand/collapse delegation for tool rows
+  // "Show more", code-block toggle, and expand/collapse delegation for tool rows
   timeline.addEventListener('click', (e) => {
+    // Collapsible code block toggle
+    const toggle = e.target.closest('.sv-code-toggle');
+    if (toggle) {
+      const wrapper = toggle.closest('.sv-code-wrapper');
+      if (wrapper) {
+        const isCollapsed = wrapper.classList.toggle('collapsed');
+        toggle.textContent = isCollapsed ? toggle.dataset.labelShow : toggle.dataset.labelHide;
+      }
+      return;
+    }
+
     // Show more button for truncated output
     const btn = e.target.closest('.sv-show-more');
     if (btn) {


### PR DESCRIPTION
自动修复 Issue #78

Closes #78

## Changes
- Reduced message font size from 14px to 12px for more compact display
- Added markdown rendering using marked.js (GFM + line breaks)
- Added collapsible code blocks (collapsed by default for blocks exceeding 10 lines)
- Full markdown support: headers, lists, links, inline code, code blocks, blockquotes, tables

## Files Modified
- `projects/openclaw-explorer/public/css/session-viewer.css`
- `projects/openclaw-explorer/public/pages/session-viewer.html`

docker-compose.yml was NOT modified.