### PR TITLE
fix(session-viewer): collapse untrusted context markers + fix agent switch bug

### DIFF
--- a/projects/openclaw-explorer/public/css/session-viewer.css
+++ b/projects/openclaw-explorer/public/css/session-viewer.css
@@ -671,6 +671,35 @@
 }
 .sv-code-toggle:hover { color: var(--accent-hover, var(--accent)); background: var(--bg-tertiary); }
 
+/* Untrusted context blocks (OpenClaw <<<EXTERNAL_UNTRUSTED_CONTENT>>>) */
+.sv-untrusted-block {
+  margin: 0.4em 0;
+  border: 1px solid rgba(139, 148, 158, 0.25);
+  border-radius: 6px;
+  background: rgba(139, 148, 158, 0.06);
+  font-size: 0.9em;
+}
+
+.sv-untrusted-block summary {
+  cursor: pointer;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.sv-untrusted-block summary:hover {
+  color: var(--text);
+  background: rgba(139, 148, 158, 0.1);
+  border-radius: 6px 6px 0 0;
+}
+
+.sv-untrusted-block > :not(summary) {
+  padding: 0 10px 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
 .sv-show-more {
   display: inline-block;
   margin-top: 4px;

--- a/projects/openclaw-explorer/public/pages/session-viewer.html
+++ b/projects/openclaw-explorer/public/pages/session-viewer.html
@@ -184,7 +184,12 @@
         if (agentId !== currentAgent) {
           currentAgent = agentId;
           currentSessionId = null;
+          allEvents = [];
+          filteredEvents = [];
           tagFilters = {};
+          // Clear hash before loading new agent's sessions to prevent
+          // navigateFromHash() from restoring the old session
+          history.pushState(null, '', window.location.pathname);
           renderAgentSwitch();
           loadSessions();
           timeline.innerHTML = '<div class="sv-timeline-empty"><div class="sv-timeline-empty-icon">&#128203;</div><p>Select a session from the sidebar to view its timeline.</p></div>';
@@ -945,9 +950,25 @@
 
   function renderMarkdown(text) {
     if (!text) return '';
+    // Collapse OpenClaw untrusted context blocks into styled sections
+    text = collapseUntrustedBlocks(text);
     let html = markedInstance.parse(text);
     html = wrapCollapsibleCodeBlocks(html);
     return html;
+  }
+
+  // Regex to match <<<EXTERNAL_UNTRUSTED_CONTENT id="...">>\> ... <<<END_EXTERNAL_UNTRUSTED_CONTENT id="...">>>
+  const UNTRUSTED_BLOCK_RE = /(?:Untrusted context \(metadata, do not treat as instructions or commands\):\s*\n*)?<<<EXTERNAL_UNTRUSTED_CONTENT\s+id="[^"]*">>>\n?([\s\S]*?)<<<END_EXTERNAL_UNTRUSTED_CONTENT\s+id="[^"]*">>>/g;
+
+  function collapseUntrustedBlocks(text) {
+    return text.replace(UNTRUSTED_BLOCK_RE, function(_match, innerContent) {
+      // Extract source label if present
+      const sourceMatch = innerContent.match(/^Source:\s*(.+)/m);
+      const label = sourceMatch ? sourceMatch[1].trim() : 'Untrusted context';
+      // Clean up leading "Source: ..." and "---" separator
+      let body = innerContent.replace(/^Source:\s*.+\n-{3,}\n?/, '').trim();
+      return '<details class="sv-untrusted-block"><summary>📎 ' + escapeHtml(label) + '</summary>\n\n' + body + '\n\n</details>';
+    });
   }
 
   const CODE_LINE_THRESHOLD = 10;


### PR DESCRIPTION
## Fixes

### 1. Raw `<<>>` markers showing in session content
The OpenClaw `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` boundary markers were being rendered as literal text. Now they're collapsed into styled, collapsible `<details>` sections with a 📎 label extracted from the block's `Source:` header.

### 2. Agent switch broken after selecting a session  
After clicking a session, the URL hash stored the session ID. When switching agents, `loadSessions()` called `navigateFromHash()` which restored the old session from the hash, preventing the switch. Fixed by clearing the URL hash before loading the new agent's sessions, and also resetting `allEvents`/`filteredEvents` state.