### PR TITLE
feat(session-viewer): resizable + collapsible sidebar

### DIFF
--- a/projects/openclaw-explorer/public/css/session-viewer.css
+++ b/projects/openclaw-explorer/public/css/session-viewer.css
@@ -8,11 +8,47 @@
 .sv-sidebar {
   width: 320px;
   min-width: 320px;
+  min-height: 0;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
+  transition: width 0.2s, min-width 0.2s;
+}
+
+.sv-sidebar.collapsed {
+  width: 0 !important;
+  min-width: 0 !important;
+  border-right: none;
+  padding: 0;
+}
+
+.sv-sidebar.collapsed > *:not(.sv-resize-handle) {
+  display: none;
+}
+
+/* Resize handle */
+.sv-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background: transparent;
+  z-index: 10;
+  transition: background 0.15s;
+}
+
+.sv-resize-handle:hover,
+.sv-resize-handle:active {
+  background: var(--accent);
+}
+
+.sv-sidebar.collapsed .sv-resize-handle {
+  display: none;
 }
 
 .sv-sidebar-header {
@@ -29,6 +65,7 @@
 
 .sv-session-list {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 4px 0;
 }

--- a/projects/openclaw-explorer/public/pages/session-viewer.html
+++ b/projects/openclaw-explorer/public/pages/session-viewer.html
@@ -40,6 +40,7 @@
     <div class="sv-session-list" id="sessionList">
       <div class="sv-loading"><div class="sv-spinner"></div> Loading sessions...</div>
     </div>
+    <div class="sv-resize-handle" id="resizeHandle"></div>
   </nav>
 
   <!-- Main area -->
@@ -153,6 +154,7 @@
     loginScreen.style.display = 'none';
     sidebarEl.style.display = '';
     mainArea.style.display = '';
+    restoreSidebarState();
   }
 
   // Agent switcher
@@ -989,11 +991,108 @@
     );
   }
 
-  // Mobile sidebar toggle
+  // Sidebar toggle (collapse/expand)
   const sidebarToggleBtn = document.getElementById('sidebarToggle');
+  const SIDEBAR_MIN_WIDTH = 200;
+  const SIDEBAR_MAX_WIDTH = 600;
+  const SIDEBAR_DEFAULT_WIDTH = 320;
+  const SIDEBAR_STORAGE_KEY = 'sv-sidebar-width';
+  const SIDEBAR_COLLAPSED_KEY = 'sv-sidebar-collapsed';
+
+  function getSavedSidebarWidth() {
+    const saved = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    return saved ? Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, parseInt(saved, 10))) : SIDEBAR_DEFAULT_WIDTH;
+  }
+
+  function setSidebarWidth(w) {
+    sidebarEl.style.width = w + 'px';
+    sidebarEl.style.minWidth = w + 'px';
+    localStorage.setItem(SIDEBAR_STORAGE_KEY, String(w));
+  }
+
+  function collapseSidebar() {
+    sidebarEl.classList.add('collapsed');
+    sidebarEl.style.width = '0px';
+    sidebarEl.style.minWidth = '0px';
+    sidebarToggleBtn.textContent = '\u25B6'; // ▶
+    sidebarToggleBtn.title = 'Show sidebar';
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
+  }
+
+  function expandSidebar() {
+    sidebarEl.classList.remove('collapsed');
+    const w = getSavedSidebarWidth();
+    setSidebarWidth(w);
+    sidebarToggleBtn.textContent = '\u2630'; // ☰
+    sidebarToggleBtn.title = 'Hide sidebar';
+    localStorage.removeItem(SIDEBAR_COLLAPSED_KEY);
+  }
+
   if (sidebarToggleBtn) {
     sidebarToggleBtn.addEventListener('click', () => {
-      sidebarEl.classList.toggle('open');
+      if (window.innerWidth <= 900) {
+        // Mobile: toggle overlay
+        sidebarEl.classList.toggle('open');
+      } else {
+        // Desktop: toggle collapse
+        if (sidebarEl.classList.contains('collapsed')) {
+          expandSidebar();
+        } else {
+          collapseSidebar();
+        }
+      }
+    });
+  }
+
+  // Restore sidebar state on load
+  function restoreSidebarState() {
+    if (window.innerWidth > 900) {
+      if (localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1') {
+        collapseSidebar();
+      } else {
+        const w = getSavedSidebarWidth();
+        setSidebarWidth(w);
+      }
+    }
+  }
+
+  // Sidebar resize handle
+  const resizeHandle = document.getElementById('resizeHandle');
+  if (resizeHandle) {
+    let isResizing = false;
+    let startX = 0;
+    let startWidth = 0;
+
+    resizeHandle.addEventListener('mousedown', (e) => {
+      if (sidebarEl.classList.contains('collapsed')) return;
+      isResizing = true;
+      startX = e.clientX;
+      startWidth = sidebarEl.offsetWidth;
+      sidebarEl.style.transition = 'none'; // disable transition during drag
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isResizing) return;
+      const delta = e.clientX - startX;
+      const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, startWidth + delta));
+      setSidebarWidth(newWidth);
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (isResizing) {
+        isResizing = false;
+        sidebarEl.style.transition = ''; // re-enable transition
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      }
+    });
+
+    // Double-click to reset to default width
+    resizeHandle.addEventListener('dblclick', () => {
+      setSidebarWidth(SIDEBAR_DEFAULT_WIDTH);
     });
   }
 


### PR DESCRIPTION
- Drag right edge to resize sidebar (200-600px range, double-click to reset default)
- Toggle ☰ button to collapse/expand sidebar
- Width and collapsed state persisted in localStorage
- Transition disabled during drag for smooth resizing
- Adds min-height:0 fix for flexbox scroll issue