### PR TITLE
feat: add wedding seating planner (seat.ai.jingtao.fun)

### DIFF
--- a/projects/wedding-prep/.dockerignore
+++ b/projects/wedding-prep/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+.gitignore
+README.md

--- a/projects/wedding-prep/.gitignore
+++ b/projects/wedding-prep/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+/data/

--- a/projects/wedding-prep/Dockerfile
+++ b/projects/wedding-prep/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+COPY server/ ./server/
+COPY client/ ./client/
+
+RUN mkdir -p /data
+
+EXPOSE 3000
+
+CMD ["node", "server/index.js"]

--- a/projects/wedding-prep/README.md
+++ b/projects/wedding-prep/README.md
@@ -1,0 +1,55 @@
+# Wedding Prep
+
+A mobile-first wedding item preparation and checklist web app. Each project gets a unique UUID-based URL — knowing the URL is the only credential needed to access it.
+
+## Features
+
+- Create named projects with unguessable UUID URLs
+- Add, edit, and delete preparation items
+- Filter by venue, person in charge, or status
+- Color-coded status badges
+- Mobile-first, touch-friendly UI with Chinese labels
+- JSON file-based storage with atomic writes
+
+## Item Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Item name |
+| quantity | number | Quantity needed |
+| venue | enum | Location: 丰县, 婚房, 婚礼现场, 宴会厅, 埠口家 |
+| person | enum | Person in charge: 张景涛, 渠琪, 丛领兹 |
+| status | enum | Status: 采买中, 已收货, 已取货, 已就绪 |
+| nextCheckDate | date | Next check-in date (optional) |
+| notes | string | Free-text notes (optional) |
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/projects` | Create a new project |
+| GET | `/api/projects/:uuid` | Get project with items |
+| POST | `/api/projects/:uuid/items` | Add an item |
+| PUT | `/api/projects/:uuid/items/:itemId` | Update an item |
+| DELETE | `/api/projects/:uuid/items/:itemId` | Delete an item |
+
+No list/enumerate endpoint exists by design — UUID is the access credential.
+
+## Deployment
+
+```bash
+docker compose up -d
+```
+
+Accessible at `https://prep.${S_DOMAIN}`.
+
+Data is persisted in the `wedding-prep-data` Docker volume at `/data/projects.json`.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Server runs on port 3000 with `--watch` for auto-reload.

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -317,7 +317,15 @@
             ),
           )
         : h("div", { className: "modal-title-row" },
+            h("button", {
+              className: "btn btn-secondary btn-sm",
+              onClick: () => overlay.remove(),
+            }, "取消"),
             h("h2", null, "添加物品"),
+            h("button", {
+              className: "btn btn-primary btn-sm",
+              onClick: () => handleSaveItem(overlay, item),
+            }, "添加"),
           ),
 
       h("div", { className: "form-group" },
@@ -354,19 +362,6 @@
         h("label", null, "备注"),
         h("textarea", { id: "f-notes", placeholder: "可选备注", onInput: onFieldChange }, fields.notes),
       ),
-
-      !isEdit
-        ? h("div", { className: "form-actions" },
-            h("button", {
-              className: "btn btn-secondary",
-              onClick: () => overlay.remove(),
-            }, "取消"),
-            h("button", {
-              className: "btn btn-primary",
-              onClick: () => handleSaveItem(overlay, item),
-            }, "添加"),
-          )
-        : null,
     );
 
     overlay.appendChild(modal);

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -1,0 +1,430 @@
+(function () {
+  "use strict";
+
+  const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家"];
+  const PERSONS = ["张景涛", "渠琪", "丛领兹"];
+  const STATUSES = ["采买中", "已收货", "已取货", "已就绪"];
+
+  const app = document.getElementById("app");
+  let state = { page: "loading", project: null, filters: {} };
+
+  // --- Routing ---
+  function getRoute() {
+    const path = window.location.pathname;
+    const match = path.match(/^\/p\/([0-9a-f-]{36})$/);
+    return match ? { page: "project", uuid: match[1] } : { page: "landing" };
+  }
+
+  function navigate(url) {
+    history.pushState(null, "", url);
+    init();
+  }
+
+  window.addEventListener("popstate", init);
+
+  // --- API ---
+  async function api(method, path, body) {
+    const opts = {
+      method,
+      headers: { "Content-Type": "application/json" },
+    };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch("/api" + path, opts);
+    if (res.status === 204) return null;
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || "请求失败");
+    return data;
+  }
+
+  // --- Render helpers ---
+  function h(tag, attrs, ...children) {
+    const el = document.createElement(tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k.startsWith("on") && typeof v === "function") {
+          el.addEventListener(k.slice(2).toLowerCase(), v);
+        } else if (k === "className") {
+          el.className = v;
+        } else if (k === "htmlFor") {
+          el.setAttribute("for", v);
+        } else {
+          el.setAttribute(k, v);
+        }
+      }
+    }
+    for (const child of children.flat()) {
+      if (child == null) continue;
+      el.appendChild(
+        typeof child === "string" ? document.createTextNode(child) : child,
+      );
+    }
+    return el;
+  }
+
+  function clear() {
+    app.innerHTML = "";
+  }
+
+  // --- Landing page ---
+  function renderLanding() {
+    clear();
+    const container = h("div", { className: "landing" },
+      h("div", null,
+        h("h1", null, "婚礼筹备清单"),
+        h("p", null, "轻松管理婚礼物品准备"),
+      ),
+      h("button", {
+        className: "btn btn-primary",
+        onClick: () => showCreateDialog(),
+      }, "+ 创建新项目"),
+    );
+    app.appendChild(container);
+  }
+
+  function showCreateDialog() {
+    clear();
+    const container = h("div", { className: "landing" },
+      h("div", { className: "create-dialog" },
+        h("h2", null, "创建新项目"),
+        h("div", { className: "form-group" },
+          h("label", null, "项目名称"),
+          h("input", {
+            type: "text",
+            id: "project-name",
+            placeholder: "例如：婚礼筹备",
+            value: "婚礼筹备",
+          }),
+        ),
+        h("div", { className: "form-actions" },
+          h("button", {
+            className: "btn btn-secondary",
+            onClick: () => renderLanding(),
+          }, "取消"),
+          h("button", {
+            className: "btn btn-primary",
+            onClick: handleCreate,
+          }, "创建"),
+        ),
+      ),
+    );
+    app.appendChild(container);
+    document.getElementById("project-name").select();
+  }
+
+  async function handleCreate() {
+    const input = document.getElementById("project-name");
+    const name = input.value.trim();
+    if (!name) return;
+    try {
+      const project = await api("POST", "/projects", { name });
+      navigate("/p/" + project.id);
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  // --- Project page ---
+  async function loadProject(uuid) {
+    clear();
+    app.appendChild(h("div", { className: "loading" }, "加载中..."));
+    try {
+      const project = await api("GET", "/projects/" + uuid);
+      state.project = project;
+      state.filters = {};
+      renderProject();
+    } catch (err) {
+      clear();
+      app.appendChild(
+        h("div", { className: "empty" },
+          h("p", null, "项目不存在或链接无效"),
+          h("button", {
+            className: "btn btn-primary",
+            style: "margin-top:16px",
+            onClick: () => navigate("/"),
+          }, "返回首页"),
+        ),
+      );
+    }
+  }
+
+  function getFilteredItems() {
+    let items = state.project.items || [];
+    const f = state.filters;
+    if (f.venue) items = items.filter((i) => i.venue === f.venue);
+    if (f.person) items = items.filter((i) => i.person === f.person);
+    if (f.status) items = items.filter((i) => i.status === f.status);
+    return items;
+  }
+
+  function renderProject() {
+    clear();
+    const p = state.project;
+    const items = getFilteredItems();
+
+    // Header
+    app.appendChild(
+      h("div", { className: "project-header" },
+        h("h1", null, p.name),
+        h("div", { className: "meta" }, `共 ${p.items.length} 项`),
+      ),
+    );
+
+    // Share bar
+    const shareUrl = window.location.origin + "/p/" + p.id;
+    const shareInput = h("input", { type: "text", value: shareUrl, readOnly: "true" });
+    app.appendChild(
+      h("div", { className: "share-bar" },
+        shareInput,
+        h("button", {
+          className: "btn btn-secondary btn-sm",
+          onClick: () => {
+            shareInput.select();
+            navigator.clipboard.writeText(shareUrl);
+          },
+        }, "复制"),
+      ),
+    );
+
+    // Summary bar
+    const statusCounts = {};
+    for (const s of STATUSES) statusCounts[s] = 0;
+    for (const item of p.items) {
+      if (statusCounts[item.status] !== undefined) statusCounts[item.status]++;
+    }
+    app.appendChild(
+      h("div", { className: "summary-bar" },
+        ...STATUSES.map((s) =>
+          h("span", { className: `summary-chip status-${s}` }, `${s} ${statusCounts[s]}`),
+        ),
+      ),
+    );
+
+    // Filters
+    app.appendChild(
+      h("div", { className: "filters" },
+        makeSelect("场地", VENUES, state.filters.venue, (v) => {
+          state.filters.venue = v;
+          renderProject();
+        }),
+        makeSelect("负责人", PERSONS, state.filters.person, (v) => {
+          state.filters.person = v;
+          renderProject();
+        }),
+        makeSelect("状态", STATUSES, state.filters.status, (v) => {
+          state.filters.status = v;
+          renderProject();
+        }),
+      ),
+    );
+
+    // Add button
+    app.appendChild(
+      h("div", { className: "toolbar" },
+        h("button", {
+          className: "btn btn-primary btn-block",
+          onClick: () => showItemModal(),
+        }, "+ 添加物品"),
+      ),
+    );
+
+    // Item list
+    if (items.length === 0) {
+      app.appendChild(
+        h("div", { className: "empty" },
+          h("p", null, state.project.items.length === 0 ? "还没有物品，点击上方按钮添加" : "没有匹配的物品"),
+        ),
+      );
+    } else {
+      const list = h("div", { className: "item-list" });
+      for (const item of items) {
+        list.appendChild(renderItemCard(item));
+      }
+      app.appendChild(list);
+    }
+  }
+
+  function makeSelect(label, options, current, onChange) {
+    const sel = h("select", {
+      className: "filter-select",
+      onChange: (e) => onChange(e.target.value || ""),
+    },
+      h("option", { value: "" }, label),
+      ...options.map((o) => {
+        const opt = h("option", { value: o }, o);
+        if (current === o) opt.selected = true;
+        return opt;
+      }),
+    );
+    return sel;
+  }
+
+  function renderItemCard(item) {
+    const tags = [
+      item.venue ? h("span", { className: "tag tag-venue" }, item.venue) : null,
+      item.person ? h("span", { className: "tag tag-person" }, item.person) : null,
+      h("span", { className: `tag tag-status status-${item.status}` }, item.status),
+      item.quantity > 1 ? h("span", { className: "tag tag-qty" }, `x${item.quantity}`) : null,
+    ].filter(Boolean);
+
+    const card = h("div", {
+      className: "item-card",
+      onClick: () => showItemModal(item),
+    },
+      h("div", { className: "item-name" }, item.name),
+      h("div", { className: "item-details" }, ...tags),
+      item.notes ? h("div", { className: "item-notes" }, item.notes) : null,
+      item.nextCheckDate ? h("div", { className: "item-date" }, `下次关注: ${item.nextCheckDate}`) : null,
+    );
+    return card;
+  }
+
+  // --- Item modal ---
+  function showItemModal(item) {
+    const isEdit = !!item;
+    const overlay = h("div", { className: "modal-overlay", onClick: (e) => {
+      if (e.target === overlay) overlay.remove();
+    }});
+
+    const fields = {
+      name: item?.name || "",
+      quantity: item?.quantity || 1,
+      venue: item?.venue || "",
+      person: item?.person || "",
+      status: item?.status || "采买中",
+      nextCheckDate: item?.nextCheckDate || "",
+      notes: item?.notes || "",
+    };
+
+    const modal = h("div", { className: "modal" },
+      h("h2", null, isEdit ? "编辑物品" : "添加物品"),
+
+      h("div", { className: "form-group" },
+        h("label", null, "名称"),
+        h("input", { type: "text", id: "f-name", value: fields.name, placeholder: "物品名称" }),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "数量"),
+        h("input", { type: "number", id: "f-quantity", value: String(fields.quantity), min: "1" }),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "使用场地"),
+        makeFormSelect("f-venue", VENUES, fields.venue, "选择场地"),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "负责人"),
+        makeFormSelect("f-person", PERSONS, fields.person, "选择负责人"),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "状态"),
+        makeFormSelect("f-status", STATUSES, fields.status, ""),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "下次关注日"),
+        h("input", { type: "date", id: "f-nextCheckDate", value: fields.nextCheckDate }),
+      ),
+      h("div", { className: "form-group" },
+        h("label", null, "备注"),
+        h("textarea", { id: "f-notes", placeholder: "可选备注" }, fields.notes),
+      ),
+
+      h("div", { className: "form-actions" },
+        h("button", {
+          className: "btn btn-secondary",
+          onClick: () => overlay.remove(),
+        }, "取消"),
+        h("button", {
+          className: "btn btn-primary",
+          onClick: () => handleSaveItem(overlay, item),
+        }, "保存"),
+      ),
+
+      isEdit ? h("div", { className: "delete-row" },
+        h("button", {
+          className: "btn btn-danger btn-block btn-sm",
+          onClick: () => handleDeleteItem(overlay, item),
+        }, "删除此物品"),
+      ) : null,
+    );
+
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+
+    // Focus name input
+    setTimeout(() => document.getElementById("f-name")?.focus(), 100);
+  }
+
+  function makeFormSelect(id, options, current, placeholder) {
+    const sel = h("select", { id },
+      placeholder ? h("option", { value: "" }, placeholder) : null,
+      ...options.map((o) => {
+        const opt = h("option", { value: o }, o);
+        if (current === o) opt.selected = true;
+        return opt;
+      }),
+    );
+    return sel;
+  }
+
+  function getFormData() {
+    return {
+      name: document.getElementById("f-name").value.trim(),
+      quantity: parseInt(document.getElementById("f-quantity").value, 10) || 1,
+      venue: document.getElementById("f-venue").value,
+      person: document.getElementById("f-person").value,
+      status: document.getElementById("f-status").value,
+      nextCheckDate: document.getElementById("f-nextCheckDate").value || null,
+      notes: document.getElementById("f-notes").value.trim(),
+    };
+  }
+
+  async function handleSaveItem(overlay, existing) {
+    const data = getFormData();
+    if (!data.name) {
+      alert("请输入物品名称");
+      return;
+    }
+    try {
+      if (existing) {
+        await api("PUT", `/projects/${state.project.id}/items/${existing.id}`, data);
+      } else {
+        await api("POST", `/projects/${state.project.id}/items`, data);
+      }
+      overlay.remove();
+      await refreshProject();
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  async function handleDeleteItem(overlay, item) {
+    if (!confirm("确定删除「" + item.name + "」？")) return;
+    try {
+      await api("DELETE", `/projects/${state.project.id}/items/${item.id}`);
+      overlay.remove();
+      await refreshProject();
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  async function refreshProject() {
+    try {
+      state.project = await api("GET", "/projects/" + state.project.id);
+      renderProject();
+    } catch (err) {
+      alert("刷新失败: " + err.message);
+    }
+  }
+
+  // --- Init ---
+  function init() {
+    const route = getRoute();
+    if (route.page === "project") {
+      loadProject(route.uuid);
+    } else {
+      renderLanding();
+    }
+  }
+
+  init();
+})();

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -203,15 +203,15 @@
     // Filters
     app.appendChild(
       h("div", { className: "filters" },
-        makeSelect("场地", VENUES, state.filters.venue, (v) => {
+        makeSelect("所有场地", VENUES, state.filters.venue, (v) => {
           state.filters.venue = v;
           renderProject();
         }),
-        makeSelect("负责人", PERSONS, state.filters.person, (v) => {
+        makeSelect("所有负责人", PERSONS, state.filters.person, (v) => {
           state.filters.person = v;
           renderProject();
         }),
-        makeSelect("状态", STATUSES, state.filters.status, (v) => {
+        makeSelect("所有状态", STATUSES, state.filters.status, (v) => {
           state.filters.status = v;
           renderProject();
         }),

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家"];
+  const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家", "北京"];
   const PERSONS = ["张景涛", "渠琪", "丛领兹"];
   const STATUSES = ["采买中", "已收货", "已取货", "已就绪"];
   const UNITS = ["件", "每人件", "斤"];

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -4,7 +4,7 @@
   const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家", "北京"];
   const PERSONS = ["张景涛", "渠琪", "丛领兹"];
   const STATUSES = ["采买中", "已收货", "已取货", "已就绪"];
-  const UNITS = ["件", "每人件", "斤"];
+  const UNITS = ["件", "件/每人", "斤"];
 
   const app = document.getElementById("app");
   let state = { page: "loading", project: null, filters: {} };

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -307,7 +307,10 @@
     function onFieldChange() {
       if (!isEdit) return;
       if (autoSaveTimer) clearTimeout(autoSaveTimer);
-      if (savingIndicator) savingIndicator.textContent = "正在保存...";
+      if (savingIndicator) {
+        savingIndicator.textContent = "⏳ 保存中...";
+        savingIndicator.className = "save-indicator saving";
+      }
       autoSaveTimer = setTimeout(() => doAutoSave(overlay, item), 500);
     }
 
@@ -394,12 +397,18 @@
     if (!data.name) return;
     try {
       await api("PUT", `/projects/${state.project.id}/items/${item.id}`, data);
-      if (savingIndicator) savingIndicator.textContent = "✓ 已保存";
+      if (savingIndicator) {
+        savingIndicator.textContent = "✅ 已保存";
+        savingIndicator.className = "save-indicator saved";
+      }
       // Update local state
       const idx = state.project.items.findIndex((i) => i.id === item.id);
       if (idx !== -1) Object.assign(state.project.items[idx], data);
     } catch (err) {
-      if (savingIndicator) savingIndicator.textContent = "保存失败";
+      if (savingIndicator) {
+        savingIndicator.textContent = "❌ 保存失败";
+        savingIndicator.className = "save-indicator";
+      }
     }
   }
 

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -4,6 +4,7 @@
   const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家"];
   const PERSONS = ["张景涛", "渠琪", "丛领兹"];
   const STATUSES = ["采买中", "已收货", "已取货", "已就绪"];
+  const UNITS = ["件", "每人件", "斤"];
 
   const app = document.getElementById("app");
   let state = { page: "loading", project: null, filters: {} };
@@ -263,7 +264,7 @@
       item.venue ? h("span", { className: "tag tag-venue" }, item.venue) : null,
       item.person ? h("span", { className: "tag tag-person" }, item.person) : null,
       h("span", { className: `tag tag-status status-${item.status}` }, item.status),
-      item.quantity > 1 ? h("span", { className: "tag tag-qty" }, `x${item.quantity}`) : null,
+      item.quantity ? h("span", { className: "tag tag-qty" }, `x${item.quantity}${item.unit || "件"}`) : null,
     ].filter(Boolean);
 
     const card = h("div", {
@@ -294,6 +295,7 @@
     const fields = {
       name: item?.name || "",
       quantity: item?.quantity || 1,
+      unit: item?.unit || "件",
       venue: item?.venue || "",
       person: item?.person || "",
       status: item?.status || "采买中",
@@ -324,8 +326,11 @@
       ),
       h("div", { className: "form-group" },
         h("label", null, "数量"),
-        h("input", { type: "number", id: "f-quantity", value: String(fields.quantity), min: "1",
-          onInput: onFieldChange }),
+        h("div", { className: "qty-row" },
+          h("input", { type: "number", id: "f-quantity", value: String(fields.quantity), min: "1",
+            onInput: onFieldChange }),
+          makeFormSelect("f-unit", UNITS, fields.unit, "", onFieldChange),
+        ),
       ),
       h("div", { className: "form-group" },
         h("label", null, "使用场地"),
@@ -422,6 +427,7 @@
     return {
       name: document.getElementById("f-name").value.trim(),
       quantity: parseInt(document.getElementById("f-quantity").value, 10) || 1,
+      unit: document.getElementById("f-unit").value || "件",
       venue: document.getElementById("f-venue").value,
       person: document.getElementById("f-person").value,
       status: document.getElementById("f-status").value,

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -279,10 +279,16 @@
   }
 
   // --- Item modal ---
+  let autoSaveTimer = null;
+  let savingIndicator = null;
+
   function showItemModal(item) {
     const isEdit = !!item;
     const overlay = h("div", { className: "modal-overlay", onClick: (e) => {
-      if (e.target === overlay) overlay.remove();
+      if (e.target === overlay) {
+        if (isEdit) { flushAutoSave(overlay, item); }
+        overlay.remove();
+      }
     }});
 
     const fields = {
@@ -295,48 +301,71 @@
       notes: item?.notes || "",
     };
 
+    // Auto-save handler for edit mode — debounced, fires on every field change
+    function onFieldChange() {
+      if (!isEdit) return;
+      if (autoSaveTimer) clearTimeout(autoSaveTimer);
+      if (savingIndicator) savingIndicator.textContent = "正在保存...";
+      autoSaveTimer = setTimeout(() => doAutoSave(overlay, item), 500);
+    }
+
+    savingIndicator = isEdit ? h("span", { className: "save-indicator" }, "") : null;
+
     const modal = h("div", { className: "modal" },
-      h("h2", null, isEdit ? "编辑物品" : "添加物品"),
+      h("div", { className: "modal-title-row" },
+        h("h2", null, isEdit ? "编辑物品" : "添加物品"),
+        savingIndicator,
+      ),
 
       h("div", { className: "form-group" },
         h("label", null, "名称"),
-        h("input", { type: "text", id: "f-name", value: fields.name, placeholder: "物品名称" }),
+        h("input", { type: "text", id: "f-name", value: fields.name, placeholder: "物品名称",
+          onInput: onFieldChange }),
       ),
       h("div", { className: "form-group" },
         h("label", null, "数量"),
-        h("input", { type: "number", id: "f-quantity", value: String(fields.quantity), min: "1" }),
+        h("input", { type: "number", id: "f-quantity", value: String(fields.quantity), min: "1",
+          onInput: onFieldChange }),
       ),
       h("div", { className: "form-group" },
         h("label", null, "使用场地"),
-        makeFormSelect("f-venue", VENUES, fields.venue, "选择场地"),
+        makeFormSelect("f-venue", VENUES, fields.venue, "选择场地", onFieldChange),
       ),
       h("div", { className: "form-group" },
         h("label", null, "负责人"),
-        makeFormSelect("f-person", PERSONS, fields.person, "选择负责人"),
+        makeFormSelect("f-person", PERSONS, fields.person, "选择负责人", onFieldChange),
       ),
       h("div", { className: "form-group" },
         h("label", null, "状态"),
-        makeFormSelect("f-status", STATUSES, fields.status, ""),
+        makeFormSelect("f-status", STATUSES, fields.status, "", onFieldChange),
       ),
       h("div", { className: "form-group" },
         h("label", null, "下次关注日"),
-        h("input", { type: "date", id: "f-nextCheckDate", value: fields.nextCheckDate }),
+        h("input", { type: "date", id: "f-nextCheckDate", value: fields.nextCheckDate,
+          onChange: onFieldChange }),
       ),
       h("div", { className: "form-group" },
         h("label", null, "备注"),
-        h("textarea", { id: "f-notes", placeholder: "可选备注" }, fields.notes),
+        h("textarea", { id: "f-notes", placeholder: "可选备注", onInput: onFieldChange }, fields.notes),
       ),
 
-      h("div", { className: "form-actions" },
-        h("button", {
-          className: "btn btn-secondary",
-          onClick: () => overlay.remove(),
-        }, "取消"),
-        h("button", {
-          className: "btn btn-primary",
-          onClick: () => handleSaveItem(overlay, item),
-        }, "保存"),
-      ),
+      isEdit
+        ? h("div", { className: "form-actions" },
+            h("button", {
+              className: "btn btn-secondary btn-block",
+              onClick: () => { flushAutoSave(overlay, item); overlay.remove(); },
+            }, "关闭"),
+          )
+        : h("div", { className: "form-actions" },
+            h("button", {
+              className: "btn btn-secondary",
+              onClick: () => overlay.remove(),
+            }, "取消"),
+            h("button", {
+              className: "btn btn-primary",
+              onClick: () => handleSaveItem(overlay, item),
+            }, "添加"),
+          ),
 
       isEdit ? h("div", { className: "delete-row" },
         h("button", {
@@ -353,8 +382,32 @@
     setTimeout(() => document.getElementById("f-name")?.focus(), 100);
   }
 
-  function makeFormSelect(id, options, current, placeholder) {
-    const sel = h("select", { id },
+  async function doAutoSave(overlay, item) {
+    const data = getFormData();
+    if (!data.name) return;
+    try {
+      await api("PUT", `/projects/${state.project.id}/items/${item.id}`, data);
+      if (savingIndicator) savingIndicator.textContent = "✓ 已保存";
+      // Update local state
+      const idx = state.project.items.findIndex((i) => i.id === item.id);
+      if (idx !== -1) Object.assign(state.project.items[idx], data);
+    } catch (err) {
+      if (savingIndicator) savingIndicator.textContent = "保存失败";
+    }
+  }
+
+  function flushAutoSave(overlay, item) {
+    if (autoSaveTimer) {
+      clearTimeout(autoSaveTimer);
+      autoSaveTimer = null;
+      doAutoSave(overlay, item);
+    }
+  }
+
+  function makeFormSelect(id, options, current, placeholder, onChange) {
+    const attrs = { id };
+    if (onChange) attrs.onChange = onChange;
+    const sel = h("select", attrs,
       placeholder ? h("option", { value: "" }, placeholder) : null,
       ...options.map((o) => {
         const opt = h("option", { value: o }, o);

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -113,14 +113,18 @@
   }
 
   async function handleCreate() {
+    if (saving) return;
     const input = document.getElementById("project-name");
     const name = input.value.trim();
     if (!name) return;
+    saving = true;
     try {
       const project = await api("POST", "/projects", { name });
       navigate("/p/" + project.id);
     } catch (err) {
       alert(err.message);
+    } finally {
+      saving = false;
     }
   }
 
@@ -430,12 +434,16 @@
     };
   }
 
+  let saving = false;
+
   async function handleSaveItem(overlay, existing) {
+    if (saving) return;
     const data = getFormData();
     if (!data.name) {
       alert("请输入物品名称");
       return;
     }
+    saving = true;
     try {
       if (existing) {
         await api("PUT", `/projects/${state.project.id}/items/${existing.id}`, data);
@@ -446,6 +454,8 @@
       await refreshProject();
     } catch (err) {
       alert(err.message);
+    } finally {
+      saving = false;
     }
   }
 

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -169,11 +169,13 @@
     // Header
     app.appendChild(
       h("div", { className: "project-header" },
-        h("h1", null, p.name),
-        h("button", {
-          className: "btn btn-secondary btn-sm refresh-btn",
-          onClick: () => refreshProject(),
-        }, "🔄"),
+        h("div", { className: "project-title-row" },
+          h("h1", null, p.name),
+          h("button", {
+            className: "btn btn-secondary refresh-btn",
+            onClick: () => refreshProject(),
+          }, "刷新"),
+        ),
         h("div", { className: "meta" }, `共 ${p.items.length} 项`),
       ),
     );

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -314,10 +314,24 @@
     savingIndicator = isEdit ? h("span", { className: "save-indicator" }, "") : null;
 
     const modal = h("div", { className: "modal" },
-      h("div", { className: "modal-title-row" },
-        h("h2", null, isEdit ? "编辑物品" : "添加物品"),
-        savingIndicator,
-      ),
+      isEdit
+        ? h("div", { className: "modal-title-row" },
+            h("button", {
+              className: "btn btn-danger btn-sm",
+              onClick: () => handleDeleteItem(overlay, item),
+            }, "删除"),
+            h("h2", null, "编辑物品"),
+            h("div", { className: "modal-title-right" },
+              savingIndicator,
+              h("button", {
+                className: "btn btn-secondary btn-sm",
+                onClick: () => { flushAutoSave(overlay, item); overlay.remove(); },
+              }, "关闭"),
+            ),
+          )
+        : h("div", { className: "modal-title-row" },
+            h("h2", null, "添加物品"),
+          ),
 
       h("div", { className: "form-group" },
         h("label", null, "名称"),
@@ -354,14 +368,8 @@
         h("textarea", { id: "f-notes", placeholder: "可选备注", onInput: onFieldChange }, fields.notes),
       ),
 
-      isEdit
+      !isEdit
         ? h("div", { className: "form-actions" },
-            h("button", {
-              className: "btn btn-secondary btn-block",
-              onClick: () => { flushAutoSave(overlay, item); overlay.remove(); },
-            }, "关闭"),
-          )
-        : h("div", { className: "form-actions" },
             h("button", {
               className: "btn btn-secondary",
               onClick: () => overlay.remove(),
@@ -370,14 +378,8 @@
               className: "btn btn-primary",
               onClick: () => handleSaveItem(overlay, item),
             }, "添加"),
-          ),
-
-      isEdit ? h("div", { className: "delete-row" },
-        h("button", {
-          className: "btn btn-danger btn-block btn-sm",
-          onClick: () => handleDeleteItem(overlay, item),
-        }, "删除此物品"),
-      ) : null,
+          )
+        : null,
     );
 
     overlay.appendChild(modal);

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -166,6 +166,10 @@
     app.appendChild(
       h("div", { className: "project-header" },
         h("h1", null, p.name),
+        h("button", {
+          className: "btn btn-secondary btn-sm refresh-btn",
+          onClick: () => refreshProject(),
+        }, "🔄"),
         h("div", { className: "meta" }, `共 ${p.items.length} 项`),
       ),
     );

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -3,7 +3,7 @@
 
   const VENUES = ["丰县", "婚房", "婚礼现场", "宴会厅", "埠口家", "北京"];
   const PERSONS = ["张景涛", "渠琪", "丛领兹"];
-  const STATUSES = ["采买中", "已收货", "已取货", "已就绪"];
+  const STATUSES = ["采买中", "待发货", "已收货", "已取货", "已就绪"];
   const UNITS = ["件", "件/每人", "斤"];
 
   const app = document.getElementById("app");

--- a/projects/wedding-prep/client/app.js
+++ b/projects/wedding-prep/client/app.js
@@ -170,22 +170,6 @@
       ),
     );
 
-    // Share bar
-    const shareUrl = window.location.origin + "/p/" + p.id;
-    const shareInput = h("input", { type: "text", value: shareUrl, readOnly: "true" });
-    app.appendChild(
-      h("div", { className: "share-bar" },
-        shareInput,
-        h("button", {
-          className: "btn btn-secondary btn-sm",
-          onClick: () => {
-            shareInput.select();
-            navigator.clipboard.writeText(shareUrl);
-          },
-        }, "复制"),
-      ),
-    );
-
     // Summary bar
     const statusCounts = {};
     for (const s of STATUSES) statusCounts[s] = 0;

--- a/projects/wedding-prep/client/index.html
+++ b/projects/wedding-prep/client/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <title>婚礼筹备清单</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -438,15 +438,23 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
+  gap: 8px;
 }
 .modal-title-row h2 {
   margin: 0;
+  flex: 1;
+  text-align: center;
+}
+.modal-title-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .save-indicator {
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-light);
-  transition: color 0.2s;
+  white-space: nowrap;
 }
 
 /* Quantity + unit row */

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -432,3 +432,19 @@ body {
   padding-top: 12px;
   border-top: 1px solid var(--border);
 }
+
+/* Auto-save indicator */
+.modal-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.modal-title-row h2 {
+  margin: 0;
+}
+.save-indicator {
+  font-size: 13px;
+  color: var(--text-light);
+  transition: color 0.2s;
+}

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -245,6 +245,11 @@ body {
   color: #c0392b;
 }
 
+.status-待发货 {
+  background: #fef9e2;
+  color: #92400e;
+}
+
 .status-已收货 {
   background: #fef3e2;
   color: #b45309;

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -109,12 +109,22 @@ body {
 .project-header {
   text-align: center;
   padding: 16px 0 12px;
+  position: relative;
 }
 
 .project-header h1 {
   font-size: 22px;
   font-weight: 700;
   color: var(--primary-dark);
+  display: inline;
+}
+
+.refresh-btn {
+  vertical-align: middle;
+  margin-left: 8px;
+  padding: 4px 8px !important;
+  font-size: 16px !important;
+  min-height: unset !important;
 }
 
 .project-header .meta {

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -448,3 +448,15 @@ body {
   color: var(--text-light);
   transition: color 0.2s;
 }
+
+/* Quantity + unit row */
+.qty-row {
+  display: flex;
+  gap: 8px;
+}
+.qty-row input {
+  flex: 1;
+}
+.qty-row select {
+  flex: 0 0 90px;
+}

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -1,0 +1,434 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #f5f0eb;
+  --card: #ffffff;
+  --primary: #c2766e;
+  --primary-light: #e8c4bf;
+  --primary-dark: #9e5a53;
+  --text: #3a3a3a;
+  --text-light: #8a8a8a;
+  --border: #e8e0d8;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --radius: 12px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100dvh;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#app {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 16px;
+  padding-bottom: 100px;
+}
+
+/* Landing page */
+.landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 80dvh;
+  text-align: center;
+  gap: 32px;
+}
+
+.landing h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.landing p {
+  color: var(--text-light);
+  font-size: 15px;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 48px;
+  padding: 12px 24px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn-primary:active {
+  background: var(--primary-dark);
+}
+
+.btn-secondary {
+  background: var(--border);
+  color: var(--text);
+}
+
+.btn-danger {
+  background: #e8e0d8;
+  color: #c0392b;
+}
+
+.btn-block {
+  width: 100%;
+}
+
+.btn-sm {
+  min-height: 36px;
+  padding: 8px 16px;
+  font-size: 14px;
+}
+
+/* Project header */
+.project-header {
+  text-align: center;
+  padding: 16px 0 12px;
+}
+
+.project-header h1 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.project-header .meta {
+  font-size: 13px;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+/* Toolbar */
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0;
+  flex-wrap: wrap;
+}
+
+.toolbar .btn {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Filters */
+.filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+}
+
+.filter-select {
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  font-size: 14px;
+  color: var(--text);
+  flex-shrink: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' fill='none' stroke='%238a8a8a' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}
+
+/* Item cards */
+.item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.item-card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+  position: relative;
+}
+
+.item-card:active {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+.item-card .item-name {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.item-card .item-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.tag-venue {
+  background: #e8f0fe;
+  color: #1a56db;
+}
+
+.tag-person {
+  background: #fef3e2;
+  color: #b45309;
+}
+
+.tag-qty {
+  background: #f0f0f0;
+  color: #555;
+}
+
+/* Status tags */
+.tag-status {
+  font-weight: 600;
+}
+
+.status-采买中 {
+  background: #fde8e8;
+  color: #c0392b;
+}
+
+.status-已收货 {
+  background: #fef3e2;
+  color: #b45309;
+}
+
+.status-已取货 {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.status-已就绪 {
+  background: #d1fae5;
+  color: #047857;
+}
+
+.item-card .item-notes {
+  font-size: 13px;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+.item-card .item-date {
+  font-size: 12px;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+/* Empty state */
+.empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-light);
+}
+
+.empty p {
+  font-size: 15px;
+}
+
+/* Modal overlay */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.modal {
+  background: var(--card);
+  border-radius: 20px 20px 0 0;
+  padding: 20px 16px 32px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 90dvh;
+  overflow-y: auto;
+  animation: slideUp 0.25s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+.modal h2 {
+  font-size: 18px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 16px;
+  color: var(--primary-dark);
+}
+
+/* Form */
+.form-group {
+  margin-bottom: 14px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 16px;
+  color: var(--text);
+  background: #fafafa;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.form-group textarea {
+  min-height: 60px;
+  resize: vertical;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-light);
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.form-actions .btn {
+  flex: 1;
+}
+
+/* Create project dialog */
+.create-dialog {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 24px 16px;
+  box-shadow: var(--shadow);
+  width: 100%;
+}
+
+.create-dialog h2 {
+  font-size: 18px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 16px;
+  color: var(--primary-dark);
+}
+
+/* Summary bar */
+.summary-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.summary-chip {
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #f0f0f0;
+  color: var(--text);
+}
+
+/* Loading */
+.loading {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-light);
+  font-size: 15px;
+}
+
+/* Share link bar */
+.share-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 16px;
+  padding: 10px 12px;
+  background: var(--card);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.share-bar input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  color: var(--text-light);
+  outline: none;
+  min-width: 0;
+}
+
+.share-bar .btn-sm {
+  flex-shrink: 0;
+}
+
+/* Delete confirmation */
+.delete-row {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -452,9 +452,17 @@ body {
   gap: 8px;
 }
 .save-indicator {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-light);
   white-space: nowrap;
+  font-weight: 500;
+  transition: color 0.3s;
+}
+.save-indicator.saved {
+  color: #16a34a;
+}
+.save-indicator.saving {
+  color: #f59e0b;
 }
 
 /* Quantity + unit row */

--- a/projects/wedding-prep/client/style.css
+++ b/projects/wedding-prep/client/style.css
@@ -109,21 +109,24 @@ body {
 .project-header {
   text-align: center;
   padding: 16px 0 12px;
-  position: relative;
+}
+
+.project-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
 .project-header h1 {
   font-size: 22px;
   font-weight: 700;
   color: var(--primary-dark);
-  display: inline;
 }
 
 .refresh-btn {
-  vertical-align: middle;
-  margin-left: 8px;
-  padding: 4px 8px !important;
-  font-size: 16px !important;
+  padding: 6px 14px !important;
+  font-size: 14px !important;
   min-height: unset !important;
 }
 

--- a/projects/wedding-prep/docker-compose.yml
+++ b/projects/wedding-prep/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  wedding-prep:
+    build: .
+    container_name: wedding-prep-app
+    restart: always
+    environment:
+      - VIRTUAL_HOST=prep.${S_DOMAIN}
+      - VIRTUAL_PORT=3000
+      - LETSENCRYPT_HOST=prep.${S_DOMAIN}
+    volumes:
+      - wedding-prep-data:/data
+    expose:
+      - "3000"
+    networks:
+      - nginx-proxy
+
+volumes:
+  wedding-prep-data:
+
+networks:
+  nginx-proxy:
+    external: true

--- a/projects/wedding-prep/package-lock.json
+++ b/projects/wedding-prep/package-lock.json
@@ -1,0 +1,841 @@
+{
+  "name": "wedding-prep",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wedding-prep",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.21.0",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/projects/wedding-prep/package.json
+++ b/projects/wedding-prep/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wedding-prep",
+  "version": "1.0.0",
+  "description": "Wedding item preparation and checklist web app",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "node --watch server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "uuid": "^10.0.0"
+  }
+}

--- a/projects/wedding-prep/server/index.js
+++ b/projects/wedding-prep/server/index.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const path = require("path");
+const routes = require("./routes");
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, "../client")));
+app.use("/api", routes);
+
+// SPA fallback — serve index.html for /p/:uuid routes
+app.get("/p/*", (req, res) => {
+  res.sendFile(path.join(__dirname, "../client/index.html"));
+});
+
+app.listen(PORT, () => {
+  console.log(`Wedding prep server running on port ${PORT}`);
+});

--- a/projects/wedding-prep/server/routes.js
+++ b/projects/wedding-prep/server/routes.js
@@ -1,0 +1,81 @@
+const express = require("express");
+const storage = require("./storage");
+
+const router = express.Router();
+
+// Create a new project
+router.post("/projects", async (req, res) => {
+  const { name } = req.body;
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: "项目名称不能为空" });
+  }
+  try {
+    const project = await storage.createProject(name.trim());
+    res.status(201).json(project);
+  } catch (err) {
+    console.error("Create project error:", err);
+    res.status(500).json({ error: "创建项目失败" });
+  }
+});
+
+// Get project by UUID
+router.get("/projects/:uuid", (req, res) => {
+  try {
+    const project = storage.getProject(req.params.uuid);
+    if (!project) {
+      return res.status(404).json({ error: "项目不存在" });
+    }
+    res.json(project);
+  } catch (err) {
+    console.error("Get project error:", err);
+    res.status(500).json({ error: "获取项目失败" });
+  }
+});
+
+// Add item to project
+router.post("/projects/:uuid/items", async (req, res) => {
+  try {
+    const item = await storage.addItem(req.params.uuid, req.body);
+    if (!item) {
+      return res.status(404).json({ error: "项目不存在" });
+    }
+    res.status(201).json(item);
+  } catch (err) {
+    console.error("Add item error:", err);
+    res.status(500).json({ error: "添加物品失败" });
+  }
+});
+
+// Update item
+router.put("/projects/:uuid/items/:itemId", async (req, res) => {
+  try {
+    const item = await storage.updateItem(
+      req.params.uuid,
+      req.params.itemId,
+      req.body,
+    );
+    if (!item) {
+      return res.status(404).json({ error: "物品不存在" });
+    }
+    res.json(item);
+  } catch (err) {
+    console.error("Update item error:", err);
+    res.status(500).json({ error: "更新物品失败" });
+  }
+});
+
+// Delete item
+router.delete("/projects/:uuid/items/:itemId", async (req, res) => {
+  try {
+    const ok = await storage.deleteItem(req.params.uuid, req.params.itemId);
+    if (!ok) {
+      return res.status(404).json({ error: "物品不存在" });
+    }
+    res.status(204).end();
+  } catch (err) {
+    console.error("Delete item error:", err);
+    res.status(500).json({ error: "删除物品失败" });
+  }
+});
+
+module.exports = router;

--- a/projects/wedding-prep/server/storage.js
+++ b/projects/wedding-prep/server/storage.js
@@ -70,6 +70,7 @@ function addItem(projectUuid, item) {
       id: uuidv4(),
       name: item.name,
       quantity: item.quantity || 1,
+      unit: item.unit || "件",
       venue: item.venue || "",
       person: item.person || "",
       status: item.status || "采买中",
@@ -97,6 +98,7 @@ function updateItem(projectUuid, itemId, updates) {
     const allowed = [
       "name",
       "quantity",
+      "unit",
       "venue",
       "person",
       "status",

--- a/projects/wedding-prep/server/storage.js
+++ b/projects/wedding-prep/server/storage.js
@@ -1,0 +1,132 @@
+const fs = require("fs");
+const path = require("path");
+
+const DATA_FILE = process.env.DATA_FILE || "/data/projects.json";
+const LOCK_FILE = DATA_FILE + ".lock";
+
+function ensureDataFile() {
+  const dir = path.dirname(DATA_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  if (!fs.existsSync(DATA_FILE)) {
+    fs.writeFileSync(DATA_FILE, JSON.stringify({}, null, 2));
+  }
+}
+
+function readData() {
+  ensureDataFile();
+  const raw = fs.readFileSync(DATA_FILE, "utf-8");
+  return JSON.parse(raw);
+}
+
+function writeData(data) {
+  ensureDataFile();
+  const tmp = DATA_FILE + ".tmp." + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2));
+  fs.renameSync(tmp, DATA_FILE);
+}
+
+// Simple file-based mutex — serializes all write operations
+let queue = Promise.resolve();
+
+function withLock(fn) {
+  const next = queue.then(() => fn());
+  queue = next.catch(() => {});
+  return next;
+}
+
+function getProject(uuid) {
+  const data = readData();
+  return data[uuid] || null;
+}
+
+function createProject(name) {
+  return withLock(() => {
+    const data = readData();
+    const { v4: uuidv4 } = require("uuid");
+    const uuid = uuidv4();
+    const now = new Date().toISOString();
+    data[uuid] = {
+      id: uuid,
+      name,
+      items: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    writeData(data);
+    return data[uuid];
+  });
+}
+
+function addItem(projectUuid, item) {
+  return withLock(() => {
+    const data = readData();
+    const project = data[projectUuid];
+    if (!project) return null;
+    const { v4: uuidv4 } = require("uuid");
+    const now = new Date().toISOString();
+    const newItem = {
+      id: uuidv4(),
+      name: item.name,
+      quantity: item.quantity || 1,
+      venue: item.venue || "",
+      person: item.person || "",
+      status: item.status || "采买中",
+      nextCheckDate: item.nextCheckDate || null,
+      notes: item.notes || "",
+      createdAt: now,
+      updatedAt: now,
+    };
+    project.items.push(newItem);
+    project.updatedAt = now;
+    writeData(data);
+    return newItem;
+  });
+}
+
+function updateItem(projectUuid, itemId, updates) {
+  return withLock(() => {
+    const data = readData();
+    const project = data[projectUuid];
+    if (!project) return null;
+    const idx = project.items.findIndex((i) => i.id === itemId);
+    if (idx === -1) return null;
+    const now = new Date().toISOString();
+    const item = project.items[idx];
+    const allowed = [
+      "name",
+      "quantity",
+      "venue",
+      "person",
+      "status",
+      "nextCheckDate",
+      "notes",
+    ];
+    for (const key of allowed) {
+      if (updates[key] !== undefined) {
+        item[key] = updates[key];
+      }
+    }
+    item.updatedAt = now;
+    project.updatedAt = now;
+    writeData(data);
+    return item;
+  });
+}
+
+function deleteItem(projectUuid, itemId) {
+  return withLock(() => {
+    const data = readData();
+    const project = data[projectUuid];
+    if (!project) return false;
+    const idx = project.items.findIndex((i) => i.id === itemId);
+    if (idx === -1) return false;
+    project.items.splice(idx, 1);
+    project.updatedAt = new Date().toISOString();
+    writeData(data);
+    return true;
+  });
+}
+
+module.exports = { getProject, createProject, addItem, updateItem, deleteItem };

--- a/projects/wedding-seating/.dockerignore
+++ b/projects/wedding-seating/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+data
+.git
+.gitignore
+README.md

--- a/projects/wedding-seating/.gitignore
+++ b/projects/wedding-seating/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/

--- a/projects/wedding-seating/Dockerfile
+++ b/projects/wedding-seating/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+RUN mkdir -p /data
+
+EXPOSE 80
+
+CMD ["node", "server.js"]

--- a/projects/wedding-seating/README.md
+++ b/projects/wedding-seating/README.md
@@ -1,0 +1,49 @@
+# Wedding Seating Planner
+
+Wedding banquet seating arrangement tool (婚礼喜宴座位安排).
+
+## Overview
+
+A mobile-first web application for planning wedding banquet seating. Guests can be assigned to tables with specific seat positions (主陪, 副陪, 1席-8席).
+
+## Features
+
+- Add/remove guests to an unassigned pool
+- Create/delete tables with custom labels
+- Assign guests to tables with optional seat labels
+- 10-seat layout per table: 主陪, 副陪, 1席-8席
+- Color-coded table status (green=full, yellow=under, red=over)
+- Mobile-first responsive design
+- Chinese UI
+
+## Tech Stack
+
+- **Backend**: Node.js + Express
+- **Frontend**: Vanilla HTML/CSS/JS (single file, no build step)
+- **Storage**: Single JSON file (`/data/seating.json`)
+
+## Deployment
+
+```bash
+docker compose up -d --build
+```
+
+Accessible at: https://seat.ai.jingtao.fun
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /api/data | Get full seating data |
+| POST | /api/guests | Add guest |
+| PUT | /api/guests/:id | Update guest |
+| DELETE | /api/guests/:id | Delete guest |
+| POST | /api/tables | Add table |
+| PUT | /api/tables/:id | Update table |
+| DELETE | /api/tables/:id | Delete table (empty only) |
+| POST | /api/guests/:id/assign | Assign guest to table |
+| POST | /api/guests/:id/unassign | Remove guest from table |
+
+## Data Storage
+
+All data is stored in `/data/seating.json`. Writes use atomic replacement (temp file + rename) with a serialized promise queue to prevent concurrent writes.

--- a/projects/wedding-seating/docker-compose.yml
+++ b/projects/wedding-seating/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  app:
+    build: ./
+    container_name: wedding-seating-app
+    restart: unless-stopped
+    volumes:
+      - ${S_CONTAINER_FOLDER_STATIC:-./data}:/data
+    environment:
+      VIRTUAL_HOST: seat.${S_DOMAIN:-ai.jingtao.fun}
+      VIRTUAL_PORT: 80
+      LETSENCRYPT_HOST: seat.${S_DOMAIN:-ai.jingtao.fun}
+      LETSENCRYPT_EMAIL: ${S_EMAIL:-admin@jingtao.fun}
+    expose:
+      - "80"
+    ports:
+      - "80"
+
+networks:
+  default:
+    name: nginx-proxy
+    external: true

--- a/projects/wedding-seating/package.json
+++ b/projects/wedding-seating/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wedding-seating",
+  "version": "1.0.0",
+  "description": "Wedding banquet seating planner",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "uuid": "^10.0.0"
+  }
+}

--- a/projects/wedding-seating/public/index.html
+++ b/projects/wedding-seating/public/index.html
@@ -1,0 +1,784 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>婚礼喜宴座位安排</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --gold: #c9a96e;
+  --gold-light: #f5e6c8;
+  --gold-dark: #8b6914;
+  --bg: #faf7f2;
+  --card-bg: #fff;
+  --text: #333;
+  --text-light: #777;
+  --green: #4caf50;
+  --yellow: #ff9800;
+  --red: #f44336;
+  --shadow: 0 2px 8px rgba(0,0,0,0.1);
+  --radius: 12px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  padding-bottom: 80px;
+}
+
+header {
+  background: linear-gradient(135deg, var(--gold-dark), var(--gold));
+  color: white;
+  padding: 16px 20px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+header h1 { font-size: 1.3rem; font-weight: 600; letter-spacing: 2px; }
+
+.stats {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.container { max-width: 900px; margin: 0 auto; padding: 16px; }
+
+/* --- Add Guest Section --- */
+.add-guest-section {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.add-guest-section input {
+  flex: 1;
+  padding: 10px 14px;
+  border: 2px solid var(--gold-light);
+  border-radius: var(--radius);
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.add-guest-section input:focus { border-color: var(--gold); }
+
+.btn {
+  padding: 10px 18px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 500;
+}
+
+.btn-primary {
+  background: var(--gold);
+  color: white;
+}
+.btn-primary:hover { background: var(--gold-dark); }
+.btn-primary:active { transform: scale(0.96); }
+
+.btn-danger {
+  background: var(--red);
+  color: white;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+}
+.btn-danger:hover { opacity: 0.85; }
+
+.btn-sm {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+}
+
+.btn-outline {
+  background: transparent;
+  border: 2px solid var(--gold);
+  color: var(--gold-dark);
+}
+.btn-outline:hover { background: var(--gold-light); }
+
+/* --- Unassigned Pool --- */
+.pool-section {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow);
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gold-dark);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.section-title .count {
+  font-size: 0.85rem;
+  color: var(--text-light);
+  font-weight: 400;
+}
+
+.guest-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 40px;
+}
+
+.guest-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--gold-light);
+  border-radius: 20px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  user-select: none;
+  border: 2px solid transparent;
+}
+
+.guest-chip:hover { border-color: var(--gold); transform: translateY(-1px); }
+.guest-chip:active { transform: scale(0.96); }
+
+.guest-chip .delete-btn {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #555;
+  cursor: pointer;
+  line-height: 1;
+}
+.guest-chip .delete-btn:hover { background: var(--red); color: white; }
+
+.empty-hint {
+  color: var(--text-light);
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
+
+/* --- Tables Section --- */
+.tables-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.tables-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gold-dark);
+}
+
+.tables-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 600px) {
+  .tables-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+.table-card {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: all 0.3s;
+  border-left: 5px solid var(--yellow);
+}
+.table-card.status-full { border-left-color: var(--green); }
+.table-card.status-over { border-left-color: var(--red); }
+
+.table-header {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #f0ebe2;
+}
+
+.table-info { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
+
+.table-number {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--gold-dark);
+  white-space: nowrap;
+}
+
+.table-label-input {
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: var(--text);
+  width: 100%;
+  padding: 2px 4px;
+  border-radius: 4px;
+  min-width: 0;
+}
+.table-label-input:focus {
+  outline: none;
+  background: var(--gold-light);
+}
+
+.table-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.table-count.full { background: #e8f5e9; color: var(--green); }
+.table-count.under { background: #fff3e0; color: var(--yellow); }
+.table-count.over { background: #ffebee; color: var(--red); }
+
+.table-delete-btn {
+  background: none;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 0 4px;
+  margin-left: 8px;
+}
+.table-delete-btn:hover { color: var(--red); }
+
+.table-body { padding: 12px 16px; }
+
+.seat-list { display: flex; flex-direction: column; gap: 4px; }
+
+.seat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  min-height: 34px;
+}
+.seat-row:nth-child(odd) { background: #faf7f2; }
+
+.seat-label {
+  font-weight: 600;
+  color: var(--gold-dark);
+  min-width: 42px;
+  font-size: 0.82rem;
+}
+
+.seat-guest {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.seat-guest-name { color: var(--text); }
+
+.seat-empty {
+  color: #ccc;
+  font-size: 0.82rem;
+  font-style: italic;
+}
+
+.seat-remove-btn {
+  background: none;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0 2px;
+}
+.seat-remove-btn:hover { color: var(--red); }
+
+/* Unseated guests in table */
+.unseated-section {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed #e0d9cc;
+}
+
+.unseated-title {
+  font-size: 0.78rem;
+  color: var(--text-light);
+  margin-bottom: 6px;
+}
+
+.unseated-guest {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-size: 0.88rem;
+  border-radius: 6px;
+}
+.unseated-guest:hover { background: #faf7f2; }
+
+.unseated-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* --- Modal --- */
+.modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 200;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 16px;
+}
+.modal-overlay.active { display: flex; }
+
+@media (min-width: 600px) {
+  .modal-overlay { align-items: center; }
+}
+
+.modal {
+  background: white;
+  border-radius: 16px 16px 0 0;
+  width: 100%;
+  max-width: 400px;
+  max-height: 70vh;
+  overflow-y: auto;
+  animation: slideUp 0.25s ease-out;
+}
+
+@media (min-width: 600px) {
+  .modal { border-radius: 16px; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(30px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.modal-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #f0ebe2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-header h3 { font-size: 1rem; color: var(--gold-dark); }
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #aaa;
+  cursor: pointer;
+  line-height: 1;
+}
+.modal-close:hover { color: var(--text); }
+
+.modal-body { padding: 16px 20px; }
+
+.modal-option {
+  padding: 12px 16px;
+  border: 2px solid #f0ebe2;
+  border-radius: var(--radius);
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.modal-option:hover { border-color: var(--gold); background: var(--gold-light); }
+.modal-option.occupied {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.modal-table-option {
+  padding: 14px 16px;
+  border: 2px solid #f0ebe2;
+  border-radius: var(--radius);
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.modal-table-option:hover { border-color: var(--gold); background: var(--gold-light); }
+
+.modal-table-name { font-weight: 600; }
+.modal-table-count { font-size: 0.85rem; color: var(--text-light); }
+
+/* --- Toast --- */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: #333;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  z-index: 300;
+  transition: transform 0.3s ease;
+  pointer-events: none;
+}
+.toast.show { transform: translateX(-50%) translateY(0); }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>婚礼喜宴座位安排</h1>
+  <div class="stats">
+    <span id="stats-guests">宾客: 0</span>
+    <span>|</span>
+    <span id="stats-tables">桌数: 0</span>
+    <span>|</span>
+    <span id="stats-assigned">已安排: 0</span>
+  </div>
+</header>
+
+<div class="container">
+  <!-- Add Guest -->
+  <div class="add-guest-section">
+    <input type="text" id="guest-name-input" placeholder="输入宾客姓名..." maxlength="30">
+    <button class="btn btn-primary" onclick="addGuest()">添加</button>
+  </div>
+
+  <!-- Unassigned Pool -->
+  <div class="pool-section">
+    <div class="section-title">
+      <span>未分配宾客</span>
+      <span class="count" id="pool-count">0人</span>
+    </div>
+    <div class="guest-chips" id="guest-pool"></div>
+  </div>
+
+  <!-- Tables -->
+  <div class="tables-header">
+    <h2>餐桌</h2>
+    <button class="btn btn-sm btn-outline" onclick="addTable()">+ 添加桌</button>
+  </div>
+  <div class="tables-grid" id="tables-grid"></div>
+</div>
+
+<!-- Table Select Modal -->
+<div class="modal-overlay" id="table-select-modal">
+  <div class="modal">
+    <div class="modal-header">
+      <h3 id="table-modal-title">选择餐桌</h3>
+      <button class="modal-close" onclick="closeModal('table-select-modal')">&times;</button>
+    </div>
+    <div class="modal-body" id="table-modal-body"></div>
+  </div>
+</div>
+
+<!-- Seat Select Modal -->
+<div class="modal-overlay" id="seat-select-modal">
+  <div class="modal">
+    <div class="modal-header">
+      <h3 id="seat-modal-title">选择座位</h3>
+      <button class="modal-close" onclick="closeModal('seat-select-modal')">&times;</button>
+    </div>
+    <div class="modal-body" id="seat-modal-body"></div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+const SEAT_LABELS = ['主陪', '副陪', '1席', '2席', '3席', '4席', '5席', '6席', '7席', '8席'];
+
+let data = { guests: [], tables: [] };
+
+// --- API ---
+async function api(method, path, body) {
+  const opts = { method, headers: { 'Content-Type': 'application/json' } };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch('/api' + path, opts);
+  if (res.status === 204) return null;
+  const json = await res.json();
+  if (!res.ok) {
+    toast(json.error || '操作失败');
+    throw new Error(json.error);
+  }
+  return json;
+}
+
+async function loadData() {
+  data = await api('GET', '/data');
+  render();
+}
+
+// --- Actions ---
+async function addGuest() {
+  const input = document.getElementById('guest-name-input');
+  const name = input.value.trim();
+  if (!name) return;
+  input.value = '';
+  await api('POST', '/guests', { name });
+  await loadData();
+  input.focus();
+}
+
+async function deleteGuest(id, e) {
+  if (e) e.stopPropagation();
+  await api('DELETE', '/guests/' + id);
+  await loadData();
+}
+
+async function addTable() {
+  await api('POST', '/tables');
+  await loadData();
+}
+
+async function deleteTable(id) {
+  try {
+    await api('DELETE', '/tables/' + id);
+    await loadData();
+  } catch {}
+}
+
+async function assignGuest(guestId, tableId, seatLabel) {
+  await api('POST', '/guests/' + guestId + '/assign', { tableId, seatLabel: seatLabel || null });
+  await loadData();
+}
+
+async function unassignGuest(guestId) {
+  await api('POST', '/guests/' + guestId + '/unassign');
+  await loadData();
+}
+
+async function updateTableLabel(tableId, label) {
+  await api('PUT', '/tables/' + tableId, { label });
+  // Don't reload — user is typing
+}
+
+async function changeSeat(guestId, tableId) {
+  showSeatModal(guestId, tableId);
+}
+
+// --- Modals ---
+let selectedGuestId = null;
+
+function showTableModal(guestId) {
+  selectedGuestId = guestId;
+  const guest = data.guests.find(g => g.id === guestId);
+  document.getElementById('table-modal-title').textContent = `为 ${guest.name} 选择餐桌`;
+
+  const body = document.getElementById('table-modal-body');
+  if (data.tables.length === 0) {
+    body.innerHTML = '<div class="empty-hint">暂无餐桌，请先添加桌</div>';
+  } else {
+    body.innerHTML = data.tables
+      .sort((a, b) => a.number - b.number)
+      .map(t => {
+        const count = data.guests.filter(g => g.tableId === t.id).length;
+        return `<div class="modal-table-option" onclick="selectTableForGuest('${t.id}')">
+          <div class="modal-table-name">${t.number}号桌 - ${esc(t.label)}</div>
+          <div class="modal-table-count">${count}/10 位宾客</div>
+        </div>`;
+      }).join('');
+  }
+  openModal('table-select-modal');
+}
+
+async function selectTableForGuest(tableId) {
+  closeModal('table-select-modal');
+  await assignGuest(selectedGuestId, tableId, null);
+}
+
+function showSeatModal(guestId, tableId) {
+  const guest = data.guests.find(g => g.id === guestId);
+  const tableGuests = data.guests.filter(g => g.tableId === tableId);
+
+  document.getElementById('seat-modal-title').textContent = `${guest.name} — 选择座位`;
+
+  const body = document.getElementById('seat-modal-body');
+  body.innerHTML = SEAT_LABELS.map(label => {
+    const occupant = tableGuests.find(g => g.seatLabel === label && g.id !== guestId);
+    if (occupant) {
+      return `<div class="modal-option occupied">
+        <span>${label}</span>
+        <span style="font-size:0.82rem;color:#aaa">${esc(occupant.name)}</span>
+      </div>`;
+    }
+    const isCurrent = guest.seatLabel === label;
+    return `<div class="modal-option${isCurrent ? ' selected' : ''}" onclick="selectSeat('${guestId}','${tableId}','${label}')">
+      <span>${label}</span>
+      ${isCurrent ? '<span style="color:var(--gold)">当前</span>' : '<span style="color:#ccc">空位</span>'}
+    </div>`;
+  }).join('') + `<div class="modal-option" onclick="selectSeat('${guestId}','${tableId}','')">
+    <span>取消座位指定</span>
+    <span style="color:#ccc">仅在桌</span>
+  </div>`;
+
+  openModal('seat-select-modal');
+}
+
+async function selectSeat(guestId, tableId, seatLabel) {
+  closeModal('seat-select-modal');
+  await assignGuest(guestId, tableId, seatLabel || null);
+}
+
+function openModal(id) {
+  document.getElementById(id).classList.add('active');
+}
+
+function closeModal(id) {
+  document.getElementById(id).classList.remove('active');
+}
+
+// Close modals on backdrop click
+document.querySelectorAll('.modal-overlay').forEach(el => {
+  el.addEventListener('click', e => {
+    if (e.target === el) el.classList.remove('active');
+  });
+});
+
+// --- Render ---
+function render() {
+  const unassigned = data.guests.filter(g => !g.tableId);
+  const assigned = data.guests.filter(g => g.tableId);
+
+  // Stats
+  document.getElementById('stats-guests').textContent = `宾客: ${data.guests.length}`;
+  document.getElementById('stats-tables').textContent = `桌数: ${data.tables.length}`;
+  document.getElementById('stats-assigned').textContent = `已安排: ${assigned.length}`;
+  document.getElementById('pool-count').textContent = `${unassigned.length}人`;
+
+  // Unassigned pool
+  const pool = document.getElementById('guest-pool');
+  if (unassigned.length === 0) {
+    pool.innerHTML = '<div class="empty-hint">暂无未分配宾客</div>';
+  } else {
+    pool.innerHTML = unassigned.map(g => `
+      <div class="guest-chip" onclick="showTableModal('${g.id}')">
+        <span>${esc(g.name)}</span>
+        <span class="delete-btn" onclick="deleteGuest('${g.id}', event)">&times;</span>
+      </div>
+    `).join('');
+  }
+
+  // Tables
+  const grid = document.getElementById('tables-grid');
+  const sortedTables = [...data.tables].sort((a, b) => a.number - b.number);
+
+  if (sortedTables.length === 0) {
+    grid.innerHTML = '<div class="empty-hint" style="padding:20px;text-align:center">暂无餐桌，点击"添加桌"开始安排</div>';
+    return;
+  }
+
+  grid.innerHTML = sortedTables.map(t => {
+    const tableGuests = data.guests.filter(g => g.tableId === t.id);
+    const count = tableGuests.length;
+    const statusClass = count === 10 ? 'status-full' : count > 10 ? 'status-over' : '';
+    const countClass = count === 10 ? 'full' : count > 10 ? 'over' : 'under';
+    const countText = count > 10 ? `${count}/10 超员` : `${count}/10`;
+
+    // Build seat rows
+    const seatRows = SEAT_LABELS.map(label => {
+      const guest = tableGuests.find(g => g.seatLabel === label);
+      if (guest) {
+        return `<div class="seat-row">
+          <span class="seat-label">${label}</span>
+          <div class="seat-guest">
+            <span class="seat-guest-name">${esc(guest.name)}</span>
+            <div style="display:flex;gap:4px">
+              <button class="seat-remove-btn" title="更换座位" onclick="changeSeat('${guest.id}','${t.id}')">✎</button>
+              <button class="seat-remove-btn" title="移除" onclick="unassignGuest('${guest.id}')">✕</button>
+            </div>
+          </div>
+        </div>`;
+      }
+      return `<div class="seat-row">
+        <span class="seat-label">${label}</span>
+        <span class="seat-empty">空位</span>
+      </div>`;
+    }).join('');
+
+    // Unseated guests (in table but no seat label)
+    const unseated = tableGuests.filter(g => !g.seatLabel);
+    const unseatedHtml = unseated.length > 0 ? `
+      <div class="unseated-section">
+        <div class="unseated-title">未指定座位 (${unseated.length}人)</div>
+        ${unseated.map(g => `
+          <div class="unseated-guest">
+            <span>${esc(g.name)}</span>
+            <div class="unseated-actions">
+              <button class="seat-remove-btn" title="选择座位" onclick="changeSeat('${g.id}','${t.id}')">✎</button>
+              <button class="seat-remove-btn" title="移回未分配" onclick="unassignGuest('${g.id}')">✕</button>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    ` : '';
+
+    return `<div class="table-card ${statusClass}">
+      <div class="table-header">
+        <div class="table-info">
+          <span class="table-number">${t.number}号桌</span>
+          <input class="table-label-input" value="${esc(t.label)}"
+            onchange="updateTableLabel('${t.id}', this.value)"
+            onkeydown="if(event.key==='Enter') this.blur()">
+        </div>
+        <span class="table-count ${countClass}">${countText}</span>
+        <button class="table-delete-btn" title="删除桌" onclick="deleteTable('${t.id}')">&times;</button>
+      </div>
+      <div class="table-body">
+        <div class="seat-list">${seatRows}</div>
+        ${unseatedHtml}
+      </div>
+    </div>`;
+  }).join('');
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+function toast(msg) {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.classList.add('show');
+  setTimeout(() => el.classList.remove('show'), 2000);
+}
+
+// Enter key to add guest
+document.getElementById('guest-name-input').addEventListener('keydown', e => {
+  if (e.key === 'Enter') addGuest();
+});
+
+// Initial load
+loadData();
+</script>
+</body>
+</html>

--- a/projects/wedding-seating/server.js
+++ b/projects/wedding-seating/server.js
@@ -1,0 +1,193 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+
+const app = express();
+const PORT = 80;
+const DATA_FILE = '/data/seating.json';
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// --- Atomic write with promise queue ---
+
+let writeQueue = Promise.resolve();
+
+function enqueueWrite(fn) {
+  writeQueue = writeQueue.then(fn).catch(fn);
+  return writeQueue;
+}
+
+function readData() {
+  try {
+    const raw = fs.readFileSync(DATA_FILE, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { guests: [], tables: [] };
+  }
+}
+
+function writeData(data) {
+  return enqueueWrite(() => {
+    const tmp = DATA_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2), 'utf8');
+    fs.renameSync(tmp, DATA_FILE);
+  });
+}
+
+// Ensure data dir exists
+try {
+  fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+} catch {}
+
+// Ensure data file exists
+if (!fs.existsSync(DATA_FILE)) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify({ guests: [], tables: [] }, null, 2), 'utf8');
+}
+
+// --- API Routes ---
+
+// GET full data
+app.get('/api/data', (req, res) => {
+  res.json(readData());
+});
+
+// POST add guest
+app.post('/api/guests', async (req, res) => {
+  const { name } = req.body;
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'Name is required' });
+  }
+  const data = readData();
+  const guest = {
+    id: uuidv4(),
+    name: name.trim(),
+    tableId: null,
+    seatLabel: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  data.guests.push(guest);
+  await writeData(data);
+  res.status(201).json(guest);
+});
+
+// PUT update guest
+app.put('/api/guests/:id', async (req, res) => {
+  const data = readData();
+  const guest = data.guests.find(g => g.id === req.params.id);
+  if (!guest) return res.status(404).json({ error: 'Guest not found' });
+
+  const { name, tableId, seatLabel } = req.body;
+  if (name !== undefined) guest.name = name.trim();
+  if (tableId !== undefined) guest.tableId = tableId;
+  if (seatLabel !== undefined) guest.seatLabel = seatLabel;
+  guest.updatedAt = new Date().toISOString();
+
+  await writeData(data);
+  res.json(guest);
+});
+
+// DELETE guest
+app.delete('/api/guests/:id', async (req, res) => {
+  const data = readData();
+  const idx = data.guests.findIndex(g => g.id === req.params.id);
+  if (idx === -1) return res.status(404).json({ error: 'Guest not found' });
+  data.guests.splice(idx, 1);
+  await writeData(data);
+  res.status(204).end();
+});
+
+// POST assign guest to table
+app.post('/api/guests/:id/assign', async (req, res) => {
+  const { tableId, seatLabel } = req.body;
+  if (!tableId) return res.status(400).json({ error: 'tableId is required' });
+
+  const data = readData();
+  const guest = data.guests.find(g => g.id === req.params.id);
+  if (!guest) return res.status(404).json({ error: 'Guest not found' });
+
+  const table = data.tables.find(t => t.id === tableId);
+  if (!table) return res.status(404).json({ error: 'Table not found' });
+
+  // Check seat conflict
+  if (seatLabel) {
+    const conflict = data.guests.find(
+      g => g.tableId === tableId && g.seatLabel === seatLabel && g.id !== guest.id
+    );
+    if (conflict) {
+      return res.status(409).json({ error: `Seat "${seatLabel}" is already taken by ${conflict.name}` });
+    }
+  }
+
+  guest.tableId = tableId;
+  guest.seatLabel = seatLabel || null;
+  guest.updatedAt = new Date().toISOString();
+
+  await writeData(data);
+  res.json(guest);
+});
+
+// POST unassign guest from table
+app.post('/api/guests/:id/unassign', async (req, res) => {
+  const data = readData();
+  const guest = data.guests.find(g => g.id === req.params.id);
+  if (!guest) return res.status(404).json({ error: 'Guest not found' });
+
+  guest.tableId = null;
+  guest.seatLabel = null;
+  guest.updatedAt = new Date().toISOString();
+
+  await writeData(data);
+  res.json(guest);
+});
+
+// POST add table
+app.post('/api/tables', async (req, res) => {
+  const data = readData();
+  const maxNumber = data.tables.reduce((max, t) => Math.max(max, t.number), 0);
+  const table = {
+    id: uuidv4(),
+    number: maxNumber + 1,
+    label: (req.body.label || `${maxNumber + 1}桌`).trim(),
+    createdAt: new Date().toISOString(),
+  };
+  data.tables.push(table);
+  await writeData(data);
+  res.status(201).json(table);
+});
+
+// PUT update table
+app.put('/api/tables/:id', async (req, res) => {
+  const data = readData();
+  const table = data.tables.find(t => t.id === req.params.id);
+  if (!table) return res.status(404).json({ error: 'Table not found' });
+
+  const { number, label } = req.body;
+  if (number !== undefined) table.number = number;
+  if (label !== undefined) table.label = label.trim();
+
+  await writeData(data);
+  res.json(table);
+});
+
+// DELETE table (only if empty)
+app.delete('/api/tables/:id', async (req, res) => {
+  const data = readData();
+  const idx = data.tables.findIndex(t => t.id === req.params.id);
+  if (idx === -1) return res.status(404).json({ error: 'Table not found' });
+
+  const hasGuests = data.guests.some(g => g.tableId === req.params.id);
+  if (hasGuests) {
+    return res.status(409).json({ error: 'Cannot delete table with assigned guests' });
+  }
+
+  data.tables.splice(idx, 1);
+  await writeData(data);
+  res.status(204).end();
+});
+
+app.listen(PORT, () => {
+  console.log(`Wedding Seating server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- New wedding banquet seating planner web app (婚礼喜宴座位安排)
- Mobile-first Chinese UI with guest pool, table cards, and 10-seat layout (主陪, 副陪, 1-8席)
- Color-coded table status: green (full), yellow (under), red (overcrowded)
- Node.js + Express backend with atomic JSON file storage
- Deploys to seat.ai.jingtao.fun via nginx-proxy

## Test plan
- [ ] Verify container starts: `docker compose up -d --build`
- [ ] Add guests and tables via the UI
- [ ] Assign guests to tables and specific seats
- [ ] Verify table status colors change with guest count
- [ ] Test mobile layout on phone/small screen
- [ ] Verify HTTPS access at seat.ai.jingtao.fun after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)