### PR TITLE
Sync OpenClaw config (20260410)

### DIFF
--- a/vm/host-services/open-claw/CONFIGURATION.md
+++ b/vm/host-services/open-claw/CONFIGURATION.md
@@ -33,15 +33,16 @@ All available tools are enabled in the configuration:
 | `read` | Read files from filesystem |
 | `write` | Write files to filesystem |
 | `edit` | Edit existing files |
-| `apply_patch` | Apply patches to files |
 | `browser` | Browser automation (Playwright, headless Chromium) |
-| `web` | Web access |
 | `web_fetch` | Fetch web content |
 | `web_search` | Web search capability |
 | `memory_search` | Memory semantic search |
 | `memory_get` | Memory snippet retrieval |
-| `cron` | Scheduled task execution |
 | `tts` | Text-to-speech synthesis |
+| `sessions_spawn` | Spawn isolated sub-agent sessions |
+| `sessions_send` | Send messages to other sessions |
+| `sessions_list` | List visible sessions |
+| `sessions_history` | Fetch session message history |
 
 ### Media Settings
 
@@ -107,6 +108,28 @@ All available tools are enabled in the configuration:
 | `logging.redactSensitive` | `"tools"` | Redacts sensitive data in tool logs |
 | `discovery.mdns.mode` | `"minimal"` | Limits mDNS information disclosure |
 
+## Session Management
+
+```json
+{
+  "session": {
+    "dmScope": "per-channel-peer",
+    "maintenance": {
+      "mode": "enforce",
+      "pruneDays": 7,
+      "maxEntries": 100
+    }
+  }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `dmScope` | DM session scoping (`"per-channel-peer"` — separate sessions per channel+user) |
+| `maintenance.mode` | Session maintenance mode (`"enforce"` — automatically prune old sessions) |
+| `maintenance.pruneDays` | Delete sessions older than this many days (7) |
+| `maintenance.maxEntries` | Maximum number of sessions to keep (100) |
+
 ## Environment Variables
 
 ### Required Variables
@@ -120,6 +143,9 @@ S_LITELLM_API_KEY="your-api-key-here"
 # Gateway authentication token
 OPENCLAW_GATEWAY_TOKEN="your-secure-random-token-here"
 
+# Hooks authentication token (for webhook endpoint)
+OPENCLAW_HOOKS_TOKEN="your-secure-random-token-here"
+
 # Discord bot token
 S_DISCORD_BOT_TOKEN="your-discord-bot-token-here"
 
@@ -131,6 +157,7 @@ S_AGENTMAIL_API_KEY="your-agentmail-api-key-here"
 |----------|---------|---------|
 | `S_LITELLM_API_KEY` | Authenticate with LiteLLM proxy | litellm provider, memory search |
 | `OPENCLAW_GATEWAY_TOKEN` | Authenticate gateway access | openclaw.json gateway config |
+| `OPENCLAW_HOOKS_TOKEN` | Authenticate webhook endpoint | hooks config |
 | `S_DISCORD_BOT_TOKEN` | Discord bot authentication | channels.discord config |
 | `S_AGENTMAIL_API_KEY` | AgentMail API authentication | skills.entries.agentmail |
 
@@ -173,12 +200,7 @@ openssl rand -base64 24
   "hooks": {
     "enabled": true,
     "path": "/hooks",
-    "token": "${OPENCLAW_GATEWAY_TOKEN}",
-    "allowRequestSessionKey": true,
-    "allowedSessionKeyPrefixes": [
-      "hook:",
-      "cc-task:"
-    ]
+    "token": "${OPENCLAW_HOOKS_TOKEN}",
   }
 }
 ```
@@ -187,7 +209,7 @@ openssl rand -base64 24
 |---------|-------------|
 | `enabled` | Enable/disable webhook endpoint |
 | `path` | URL path for the hooks endpoint |
-| `token` | Authentication token for incoming webhooks |
+| `token` | Authentication token for incoming webhooks (uses `OPENCLAW_HOOKS_TOKEN`) |
 | `allowRequestSessionKey` | Allow incoming hooks to specify a session key for routing |
 | `allowedSessionKeyPrefixes` | List of allowed session key prefixes (e.g., `"hook:"`, `"cc-task:"`) |
 
@@ -233,30 +255,22 @@ openssl rand -base64 24
       "model": {
         "primary": "litellm/github-copilot/claude-opus-4.6",
         "fallbacks": [
-          "litellm/github-copilot/claude-sonnet-4.5",
-          "openai-codex/gpt-5.3-codex",
-          "openai-codex/gpt-5.2-codex"
+          "litellm/github-copilot/claude-sonnet-4.6",
+          "litellm/github-copilot/claude-opus-4.6-1m",
+          "openai-codex/gpt-5.4",
+          "openai-codex/gpt-5.3-codex"
         ]
       },
       "models": {
         "litellm/github-copilot/claude-opus-4.6": {},
-        "litellm/github-copilot/claude-sonnet-4.5": {},
-        "openai-codex/gpt-5.3-codex": {},
-        "openai-codex/gpt-5.2-codex": {}
+        "litellm/github-copilot/claude-sonnet-4.6": {},
+        "litellm/github-copilot/claude-opus-4.6-1m": {},
+        "openai-codex/gpt-5.4": {},
+        "openai-codex/gpt-5.3-codex": {}
       },
       "workspace": "/home/jingtao/.openclaw/workspace",
       "compaction": {
         "mode": "safeguard"
-      },
-      "heartbeat": {
-        "every": "30m",
-        "activeHours": {
-          "start": "08:00",
-          "end": "24:00",
-          "timezone": "Asia/Shanghai"
-        },
-        "target": "discord",
-        "to": "channel:<channel-id>"
       },
       "maxConcurrent": 4,
       "subagents": {
@@ -273,12 +287,20 @@ openssl rand -base64 24
 | `model.fallbacks` | Fallback models in priority order |
 | `workspace` | Default agent workspace directory |
 | `compaction.mode` | Context compaction strategy (`"safeguard"`) |
-| `heartbeat.every` | Heartbeat polling interval (e.g., `"30m"`) |
-| `heartbeat.activeHours` | Time window for heartbeats (`start`/`end` in HH:MM, with `timezone`) |
-| `heartbeat.target` | Channel to deliver heartbeat responses (e.g., `"discord"`) |
-| `heartbeat.to` | Specific channel/user target (e.g., `"channel:<id>"`) |
 | `maxConcurrent` | Maximum concurrent agents |
 | `subagents.maxConcurrent` | Maximum concurrent subagents per agent |
+
+### Named Agents
+
+Beyond the defaults, OpenClaw supports named agent instances with dedicated workspaces and models:
+
+| Agent ID | Model | Purpose |
+|----------|-------|---------|
+| `main` | (uses defaults) | Main orchestrator agent |
+| `codex` | `openai-codex/gpt-5.4` | OpenAI Codex agent |
+| `opus` | `litellm/github-copilot/claude-opus-4.6` | Dedicated Claude Opus agent |
+| `worker-leader` | `litellm/github-copilot/claude-sonnet-4.6` | Worker orchestration leader |
+| `worker` | `litellm/github-copilot/claude-haiku-4.5` | Lightweight worker agent |
 
 ## Memory Search
 
@@ -340,6 +362,15 @@ openssl rand -base64 24
       "agentmail": {
         "enabled": true,
         "env": { "AGENTMAIL_API_KEY": "${S_AGENTMAIL_API_KEY}" }
+      },
+      "clawhub": {
+        "enabled": true
+      },
+      "coding-agent": {
+        "enabled": false
+      },
+      "claude-code-supervisor": {
+        "enabled": false
       }
     }
   }
@@ -364,13 +395,22 @@ openssl rand -base64 24
       "memory-core": {
         "enabled": true
       },
-      "whatsapp": {
-        "enabled": true
-      },
       "discord": {
         "enabled": true
       },
-      "msteams": {
+      "xai": {
+        "enabled": false
+      },
+      "litellm": {
+        "enabled": true
+      },
+      "openai": {
+        "enabled": true
+      },
+      "browser": {
+        "enabled": true
+      },
+      "memory-wiki": {
         "enabled": true
       }
     }
@@ -381,9 +421,12 @@ openssl rand -base64 24
 | Plugin | Description |
 |--------|-------------|
 | `memory-core` | Memory and embedding search plugin |
-| `whatsapp` | WhatsApp messaging integration |
 | `discord` | Discord messaging integration |
-| `msteams` | Microsoft Teams messaging integration |
+| `xai` | xAI integration (disabled) |
+| `litellm` | LiteLLM provider plugin |
+| `openai` | OpenAI provider plugin |
+| `browser` | Browser automation plugin |
+| `memory-wiki` | Memory wiki vault integration |
 
 ## Channels
 
@@ -396,7 +439,9 @@ openssl rand -base64 24
       "token": "${S_DISCORD_BOT_TOKEN}",
       "allowBots": true,
       "groupPolicy": "open",
-      "streaming": "off",
+      "streaming": {
+        "mode": "off"
+      },
       "dmPolicy": "open",
       "allowFrom": ["*"],
       "guilds": {
@@ -439,10 +484,13 @@ openssl rand -base64 24
       "provider": "openai",
       "maxTextLength": 4000,
       "timeoutMs": 30000,
-      "openai": {
-        "apiKey": "${S_LITELLM_API_KEY}",
-        "model": "gpt-4o-mini-tts",
-        "voice": "alloy"
+      "providers": {
+        "openai": {
+          "apiKey": "${S_LITELLM_API_KEY}",
+          "model": "gpt-4o-mini-tts",
+          "voice": "alloy",
+          "baseUrl": "https://litellm.us.jingtao.fun/v1"
+        }
       },
       "modelOverrides": {
         "enabled": true,
@@ -462,8 +510,9 @@ openssl rand -base64 24
 | `tts.provider` | TTS provider (`"openai"`) |
 | `tts.maxTextLength` | Maximum text length for TTS (4000 chars) |
 | `tts.timeoutMs` | TTS generation timeout in milliseconds |
-| `tts.openai.model` | OpenAI TTS model (`"gpt-4o-mini-tts"`) |
-| `tts.openai.voice` | Default voice (`"alloy"`, options: alloy, ash, coral, echo, fable, nova, onyx, sage, shimmer) |
+| `tts.providers.openai.model` | OpenAI TTS model (`"gpt-4o-mini-tts"`) |
+| `tts.providers.openai.voice` | Default voice (`"alloy"`, options: alloy, ash, coral, echo, fable, nova, onyx, sage, shimmer) |
+| `tts.providers.openai.baseUrl` | TTS API base URL (routed via LiteLLM) |
 | `tts.modelOverrides.enabled` | Allow model override tags in messages |
 | `tts.modelOverrides.allowText` | Allow text content override via tags |
 | `tts.modelOverrides.allowVoice` | Allow voice selection override via tags |

--- a/vm/host-services/open-claw/MODELS.md
+++ b/vm/host-services/open-claw/MODELS.md
@@ -22,9 +22,10 @@ OpenClaw Gateway (18789)
 
 ```
 Primary:    litellm/github-copilot/claude-opus-4.6
-Fallback 1: litellm/github-copilot/claude-sonnet-4.5
-Fallback 2: openai-codex/gpt-5.3-codex
-Fallback 3: openai-codex/gpt-5.2-codex
+Fallback 1: litellm/github-copilot/claude-sonnet-4.6
+Fallback 2: litellm/github-copilot/claude-opus-4.6-1m
+Fallback 3: openai-codex/gpt-5.4
+Fallback 4: openai-codex/gpt-5.3-codex
 ```
 
 ## Provider Configuration
@@ -51,11 +52,19 @@ Connects to the LiteLLM proxy using the OpenAI-completions API format.
             "maxTokens": 64000
           },
           {
-            "id": "github-copilot/claude-sonnet-4.5",
-            "name": "Claude Sonnet 4.5",
+            "id": "github-copilot/claude-sonnet-4.6",
+            "name": "Claude Sonnet 4.6",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "github-copilot/claude-opus-4.6-1m",
+            "name": "Claude Opus 4.6 (1M)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
             "maxTokens": 64000
           }
         ]
@@ -70,7 +79,8 @@ Connects to the LiteLLM proxy using the OpenAI-completions API format.
 | Model Ref | Context | Input | Role |
 |-----------|---------|-------|------|
 | `litellm/github-copilot/claude-opus-4.6` | 200k | text+image | Primary |
-| `litellm/github-copilot/claude-sonnet-4.5` | 200k | text+image | Fallback 1 |
+| `litellm/github-copilot/claude-sonnet-4.6` | 200k | text+image | Fallback 1 |
+| `litellm/github-copilot/claude-opus-4.6-1m` | 1M | text+image | Fallback 2 |
 
 ### openai-codex (Fallback)
 
@@ -101,8 +111,8 @@ Direct connection to OpenAI API using OAuth authentication via ChatGPT Plus acco
 
 | Model Ref | Context | Role |
 |-----------|---------|------|
-| `openai-codex/gpt-5.3-codex` | 200k | Fallback 2 |
-| `openai-codex/gpt-5.2-codex` | — | Fallback 3 |
+| `openai-codex/gpt-5.4` | 200k | Fallback 3 |
+| `openai-codex/gpt-5.3-codex` | 200k | Fallback 4 |
 
 ## Services
 

--- a/vm/host-services/open-claw/openclaw.example.json
+++ b/vm/host-services/open-claw/openclaw.example.json
@@ -13,7 +13,7 @@
         "provider": "litellm",
         "mode": "api_key"
       },
-      "openai-codex:default": {
+      "openai-codex:qfpppp@gmail.com": {
         "provider": "openai-codex",
         "mode": "oauth"
       }
@@ -21,11 +21,6 @@
   },
   "models": {
     "providers": {
-      "openai": {
-        "baseUrl": "https://litellm.us.jingtao.fun/v1",
-        "apiKey": "${S_LITELLM_API_KEY}",
-        "models": []
-      },
       "litellm": {
         "baseUrl": "https://litellm.us.jingtao.fun/",
         "apiKey": "${S_LITELLM_API_KEY}",
@@ -49,8 +44,8 @@
             "maxTokens": 64000
           },
           {
-            "id": "github-copilot/claude-sonnet-4.5",
-            "name": "Claude Sonnet 4.5",
+            "id": "github-copilot/claude-sonnet-4.6",
+            "name": "Claude Sonnet 4.6",
             "reasoning": true,
             "input": [
               "text",
@@ -64,8 +59,30 @@
             },
             "contextWindow": 200000,
             "maxTokens": 64000
+          },
+          {
+            "id": "github-copilot/claude-opus-4.6-1m",
+            "name": "Claude Opus 4.6 (1M)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0.5,
+              "cacheWrite": 6.25
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 64000
           }
         ]
+      },
+      "openai": {
+        "apiKey": "${S_LITELLM_API_KEY}",
+        "baseUrl": "https://litellm.us.jingtao.fun/v1",
+        "models": []
       }
     }
   },
@@ -74,16 +91,18 @@
       "model": {
         "primary": "litellm/github-copilot/claude-opus-4.6",
         "fallbacks": [
-          "litellm/github-copilot/claude-sonnet-4.5",
-          "openai-codex/gpt-5.3-codex",
-          "openai-codex/gpt-5.2-codex"
+          "litellm/github-copilot/claude-sonnet-4.6",
+          "litellm/github-copilot/claude-opus-4.6-1m",
+          "openai-codex/gpt-5.4",
+          "openai-codex/gpt-5.3-codex"
         ]
       },
       "models": {
         "litellm/github-copilot/claude-opus-4.6": {},
-        "litellm/github-copilot/claude-sonnet-4.5": {},
-        "openai-codex/gpt-5.3-codex": {},
-        "openai-codex/gpt-5.2-codex": {}
+        "litellm/github-copilot/claude-sonnet-4.6": {},
+        "litellm/github-copilot/claude-opus-4.6-1m": {},
+        "openai-codex/gpt-5.4": {},
+        "openai-codex/gpt-5.3-codex": {}
       },
       "workspace": "/home/jingtao/.openclaw/workspace",
       "memorySearch": {
@@ -131,21 +150,68 @@
       "compaction": {
         "mode": "safeguard"
       },
-      "heartbeat": {
-        "every": "30m",
-        "activeHours": {
-          "start": "08:00",
-          "end": "24:00",
-          "timezone": "Asia/Shanghai"
-        },
-        "target": "discord",
-        "to": "channel:1471477049108729926"
-      },
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
       }
-    }
+    },
+    "list": [
+      {
+        "id": "main",
+        "subagents": {
+          "allowAgents": [
+            "worker",
+            "worker-leader",
+            "dev-planner",
+            "dev-coder-1",
+            "debate-child-a",
+            "debate-child-b"
+          ]
+        }
+      },
+      {
+        "id": "codex",
+        "name": "codex",
+        "workspace": "/home/jingtao/.openclaw/workspace",
+        "agentDir": "/home/jingtao/.openclaw/agents/codex/agent",
+        "model": {
+          "primary": "openai-codex/gpt-5.4",
+          "fallbacks": []
+        }
+      },
+      {
+        "id": "opus",
+        "name": "opus",
+        "workspace": "/home/jingtao/.openclaw/workspace",
+        "agentDir": "/home/jingtao/.openclaw/agents/opus/agent",
+        "model": {
+          "primary": "litellm/github-copilot/claude-opus-4.6",
+          "fallbacks": []
+        }
+      },
+      {
+        "id": "worker-leader",
+        "name": "worker-leader",
+        "workspace": "/home/jingtao/.openclaw/workspace-worker-leader",
+        "agentDir": "/home/jingtao/.openclaw/agents/worker-leader/agent",
+        "model": {
+          "primary": "litellm/github-copilot/claude-sonnet-4.6",
+          "fallbacks": []
+        },
+        "subagents": {
+          "allowAgents": [
+            "worker"
+          ]
+        }
+      },
+      {
+        "id": "worker",
+        "name": "worker",
+        "workspace": "/home/jingtao/.openclaw/workspace-worker",
+        "agentDir": "/home/jingtao/.openclaw/agents/worker/agent",
+        "model": "litellm/github-copilot/claude-haiku-4.5"
+      }
+    ]
   },
   "tools": {
     "allow": [
@@ -154,15 +220,16 @@
       "read",
       "write",
       "edit",
-      "apply_patch",
       "browser",
-      "web",
       "web_fetch",
       "web_search",
       "memory_search",
       "memory_get",
-      "cron",
-      "tts"
+      "tts",
+      "sessions_spawn",
+      "sessions_send",
+      "sessions_list",
+      "sessions_history"
     ],
     "deny": [],
     "media": {
@@ -171,22 +238,59 @@
         "models": [
           {
             "provider": "openai",
-            "model": "gpt-4o-transcribe",
-            "type": "provider",
-            "timeoutSeconds": 60,
-            "baseUrl": "https://litellm.us.jingtao.fun/v1",
-            "headers": {
-              "authorization": "Bearer ${S_LITELLM_API_KEY}"
-            }
+            "model": "gpt-4o-transcribe"
           }
-        ]
+        ],
+        "timeoutSeconds": 60,
+        "echoTranscript": true
       }
+    },
+    "sessions": {
+      "visibility": "all"
+    },
+    "agentToAgent": {
+      "enabled": true
     },
     "exec": {
       "security": "full",
       "ask": "off"
     }
   },
+  "bindings": [
+    {
+      "type": "route",
+      "agentId": "codex",
+      "match": {
+        "channel": "discord",
+        "peer": {
+          "kind": "channel",
+          "id": "1488351896249827438"
+        }
+      }
+    },
+    {
+      "type": "route",
+      "agentId": "opus",
+      "match": {
+        "channel": "discord",
+        "peer": {
+          "kind": "channel",
+          "id": "1488351898187862038"
+        }
+      }
+    },
+    {
+      "type": "route",
+      "agentId": "worker-leader",
+      "match": {
+        "channel": "discord",
+        "peer": {
+          "kind": "channel",
+          "id": "1488680941495914496"
+        }
+      }
+    }
+  ],
   "messages": {
     "ackReactionScope": "group-mentions",
     "tts": {
@@ -198,10 +302,13 @@
         "allowText": true,
         "allowVoice": true
       },
-      "openai": {
-        "apiKey": "${S_LITELLM_API_KEY}",
-        "model": "gpt-4o-mini-tts",
-        "voice": "alloy"
+      "providers": {
+        "openai": {
+          "apiKey": "${S_LITELLM_API_KEY}",
+          "model": "gpt-4o-mini-tts",
+          "voice": "alloy",
+          "baseUrl": "https://litellm.us.jingtao.fun/v1"
+        }
       },
       "maxTextLength": 4000,
       "timeoutMs": 30000
@@ -214,12 +321,17 @@
     "ownerDisplay": "raw"
   },
   "session": {
-    "dmScope": "per-channel-peer"
+    "dmScope": "per-channel-peer",
+    "maintenance": {
+      "mode": "enforce",
+      "pruneDays": 7,
+      "maxEntries": 100
+    }
   },
   "hooks": {
     "enabled": true,
     "path": "/hooks",
-    "token": "${OPENCLAW_GATEWAY_TOKEN}",
+    "token": "${OPENCLAW_HOOKS_TOKEN}",
     "allowRequestSessionKey": true,
     "allowedSessionKeyPrefixes": [
       "hook:",
@@ -233,7 +345,9 @@
       "token": "${S_DISCORD_BOT_TOKEN}",
       "allowBots": true,
       "groupPolicy": "open",
-      "streaming": "off",
+      "streaming": {
+        "mode": "off"
+      },
       "dmPolicy": "open",
       "allowFrom": [
         "*"
@@ -256,6 +370,10 @@
             }
           }
         }
+      },
+      "threadBindings": {
+        "enabled": true,
+        "spawnSubagentSessions": true
       }
     }
   },
@@ -288,6 +406,15 @@
         "env": {
           "AGENTMAIL_API_KEY": "${S_AGENTMAIL_API_KEY}"
         }
+      },
+      "clawhub": {
+        "enabled": true
+      },
+      "coding-agent": {
+        "enabled": false
+      },
+      "claude-code-supervisor": {
+        "enabled": false
       }
     }
   },
@@ -297,17 +424,56 @@
     },
     "entries": {
       "memory-core": {
-        "enabled": true
-      },
-      "whatsapp": {
-        "enabled": true
+        "enabled": true,
+        "config": {}
       },
       "discord": {
+        "enabled": true,
+        "config": {}
+      },
+      "xai": {
+        "enabled": false
+      },
+      "litellm": {
         "enabled": true
       },
-      "msteams": {
+      "openai": {
         "enabled": true
+      },
+      "browser": {
+        "enabled": true
+      },
+      "memory-wiki": {
+        "enabled": true,
+        "config": {
+          "vaultMode": "isolated",
+          "vault": {
+            "path": "/home/jingtao/.openclaw/wiki/main",
+            "renderMode": "native"
+          },
+          "bridge": {
+            "enabled": false,
+            "readMemoryArtifacts": true,
+            "indexDailyNotes": true,
+            "indexMemoryRoot": true,
+            "followMemoryEvents": true,
+            "indexDreamReports": false
+          },
+          "search": {
+            "backend": "shared",
+            "corpus": "wiki"
+          },
+          "context": {
+            "includeCompiledDigestPrompt": true
+          },
+          "render": {
+            "preserveHumanBlocks": true,
+            "createBacklinks": true,
+            "createDashboards": true
+          }
+        }
       }
-    }
+    },
+    "installs": {}
   }
 }


### PR DESCRIPTION
Automated daily sync of OpenClaw configuration.

**Changes:**
- Models: Claude Sonnet 4.5 → 4.6, added Claude Opus 4.6 (1M context), gpt-5.4 added, gpt-5.2-codex removed
- Named agents: codex, opus, worker-leader, worker with dedicated workspaces
- Tools: removed apply_patch/web/cron, added sessions_spawn/send/list/history
- Heartbeat config removed from defaults
- Hooks token changed from OPENCLAW_GATEWAY_TOKEN to OPENCLAW_HOOKS_TOKEN
- TTS restructured with providers nesting and baseUrl
- Session maintenance config added (prune after 7 days, max 100 entries)
- Plugins: removed whatsapp/msteams, added xai/litellm/openai/browser/memory-wiki
- Skills: added clawhub, coding-agent, claude-code-supervisor
- Discord: streaming changed to object format, threadBindings added
- Channel routes section added
- Documentation updated (MODELS.md, CONFIGURATION.md)