### PR TITLE
Add share-hosting docker service

### DIFF
--- a/vm/docker-services/README.md
+++ b/vm/docker-services/README.md
@@ -10,6 +10,7 @@ Docker Compose services deployed using **pre-built images from public registries
 | --- | --- | --- | --- |
 | `https-proxy-services` | [nginx-proxy](https-proxy-services/nginx-proxy/) | Reverse proxy with automatic HTTPS via Let's Encrypt | [README](https-proxy-services/nginx-proxy/README.md) |
 | `paste-services` | [pastebin](paste-services/pastebin/) | Lightweight pastebin service | [README](paste-services/pastebin/README.md) |
+| `share-hosting` | [share-hosting](share-hosting/) | UUID-only static file share (scan-resistant) at `share.${S_DOMAIN}` | [README](share-hosting/README.md) |
 
 ## Directory Structure
 

--- a/vm/docker-services/share-hosting/README.md
+++ b/vm/docker-services/share-hosting/README.md
@@ -1,0 +1,51 @@
+# share-hosting
+
+Self-hosted static file share with UUID-only URLs. Scan-resistant: directory listing disabled, root returns 404, only whitelisted extensions served.
+
+**Domain:** `share.${S_DOMAIN}` (e.g. `share.ai.jingtao.fun`)
+**Allowed extensions:** `.html`, `.pdf`, `.md`, `.txt`
+**Path format:** `/<uuid-v4>.<ext>` only — anything else → 404
+
+## Deploy
+
+```bash
+cd vm/docker-services/share-hosting
+docker compose up -d
+```
+
+Static files go in `${S_CONTAINER_FOLDER_STATIC}/share-hosting/` on the host.
+
+## Share a file
+
+```bash
+UID=$(uuidgen | tr 'A-Z' 'a-z')
+cp report.html /data_static/share-hosting/${UID}.html
+echo "https://share.ai.jingtao.fun/${UID}.html"
+```
+
+URL is live immediately — no restart needed.
+
+## Security properties
+
+| Test | Result |
+|---|---|
+| `GET /<valid-uuid>.html` | 200 |
+| `GET /` | 404 |
+| `GET /index.html` (guess) | 404 |
+| Uppercase UUID | 404 (case-sensitive) |
+| Non-whitelist extension | 404 |
+| Hidden files (`.env`) | denied |
+| Directory listing | off (`autoindex off`) |
+| Server version banner | hidden (`server_tokens off`) |
+
+UUID v4 has 122 bits of entropy — brute-force enumeration is infeasible.
+
+## Nginx gotcha
+
+The `location ~* "..."` regex **must be quoted** — nginx otherwise parses `{8}` as a config block delimiter and fails with `unknown directive "8}-[0-9a-f]"`. Already handled in `nginx.conf`.
+
+## When NOT to use this
+
+- Images for chat/embed → use `image-hosting` (optimized for image MIME + long cache)
+- Quick text/code paste → use `paste-services`
+- Files needing pickup code / expiry UI → use a FileCodeBox-style service

--- a/vm/docker-services/share-hosting/docker-compose.yml
+++ b/vm/docker-services/share-hosting/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  share-hosting:
+    image: nginx:alpine
+    environment:
+      - VIRTUAL_HOST=share.${S_DOMAIN}
+      - VIRTUAL_PORT=80
+      - LETSENCRYPT_HOST=share.${S_DOMAIN}
+      - LETSENCRYPT_EMAIL=${S_EMAIL}
+    volumes:
+      - ${S_CONTAINER_FOLDER_STATIC}/share-hosting:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: always
+    container_name: share-hosting
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true

--- a/vm/docker-services/share-hosting/nginx.conf
+++ b/vm/docker-services/share-hosting/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    server_tokens off;
+
+    # No directory listing — prevents scanning
+    autoindex off;
+
+    # Block root and any directory request — no enumeration
+    location = / {
+        return 404;
+    }
+
+    # Whitelist file types only (UUID paths required)
+    location ~* "^/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(html|pdf|md|txt)$" {
+        add_header Cache-Control "private, max-age=3600";
+        add_header X-Content-Type-Options "nosniff";
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header Referrer-Policy "no-referrer";
+        try_files $uri =404;
+    }
+
+    # Everything else: 404 (no info leakage)
+    location / {
+        return 404;
+    }
+
+    # Don't serve hidden files
+    location ~ /\. {
+        deny all;
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary
Self-hosted static file share with UUID-only URLs. Scan-resistant alternative to image-hosting for HTML/PDF/MD/TXT artifacts.

## Domain
`share.${S_DOMAIN}` — already live at https://share.ai.jingtao.fun

## Security properties (verified 2026-05-30)
| Request | Result |
|---|---|
| `GET /<valid-uuid>.html` | 200 |
| `GET /` | 404 |
| `GET /index.html` (guess) | 404 |
| Uppercase UUID | 404 (case-sensitive regex) |
| Non-whitelist ext (`.exe`) | 404 |
| Hidden files (`.env`) | denied |
| Directory listing | off |

UUID v4 = 122 bits entropy → brute-force infeasible.

## Files
- `vm/docker-services/share-hosting/docker-compose.yml` — nginx:alpine, nginx-proxy network, LE auto-cert
- `vm/docker-services/share-hosting/nginx.conf` — whitelist regex (UUID-v4 paths + 4 extensions)
- `vm/docker-services/share-hosting/README.md` — usage + security model
- `vm/docker-services/README.md` — service table updated

## Nginx gotcha (documented)
The `location ~* "..."` regex MUST be quoted — unquoted `{8}` is parsed as a config block delimiter. Already handled.

## Not in scope
- No automated cleanup (intentional, per Jingtao 2026-05-30)
- No upload UI (just `cp` to `/data_static/share-hosting/`)

## Test plan
```bash
curl -sI https://share.ai.jingtao.fun/                          # 404
curl -sI https://share.ai.jingtao.fun/index.html                # 404
curl -sI https://share.ai.jingtao.fun/<known-uuid>.html         # 200
```