### PR TITLE
feat(licai): add wealth-products dashboard subdomain

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -33,6 +33,7 @@ projects/
 | [nav-portal](nav-portal/) | `nav.${S_DOMAIN}` | Navigation dashboard with Docker service auto-discovery |
 | [experience-manager](experience-manager/) | `ems.ai.jingtao.fun` | AI agent experience storage and semantic search (EMS) |
 | [ai-task-engine](ai-task-engine/) | `localhost:3200` | Workflow engine for AI task orchestration with Discord, EMS, and OpenClaw integration |
+| [licai](licai/) | `licai.${S_DOMAIN}` | Dashboard + per-product browser for the wealth-products research archive at `~/finance/wealth-products/` |
 
 ## Adding a New Project
 

--- a/projects/licai/README.md
+++ b/projects/licai/README.md
@@ -1,0 +1,39 @@
+# licai — Wealth-Products Dashboard
+
+Dedicated subdomain for Jingtao's wealth-management research archive.
+
+**URL**: https://licai.ai.jingtao.fun
+
+## What it serves
+
+- `/` → `dashboard.html` — the aggregate dashboard (auto-refreshed on every `build_dashboard.py` run)
+- `/<bank>/<code>/report.html` — individual product reports (e.g. `/icbc/25G2488A/report.html`)
+- `/<bank>/<code>/chart.svg` — net-value charts
+- `/<bank>/<code>/meta.json` — structured product metadata
+- `/<bank>/<code>/pdfs/*.pdf` — official disclosure PDFs
+
+Hidden from web (server-side raw data only):
+- `data.json` / `nv_full.json` / `reports.json` — raw API dumps
+- `*.py` — build scripts
+- `share_url.txt` — back-pointers to share-hosting
+
+## Data source
+
+Read-only mount of `/home/jingtao/finance/wealth-products/`. The dashboard regenerates on every `build_dashboard.py` run; nginx serves the freshly-written file with no restart needed.
+
+## Deploy
+
+```bash
+cd ~/ai-learn/projects/licai
+docker compose up -d
+```
+
+First request after fresh deploy may take 5-30s while letsencrypt-companion fetches a cert. Watch with:
+```bash
+docker logs -f nginx-proxy-acme | grep licai
+```
+
+## Related
+
+- **share-hosting** (`share.ai.jingtao.fun`): UUID-only file share for ad-hoc reports
+- **licai** (this): Dedicated dashboard + per-product browser for the wealth-products archive

--- a/projects/licai/docker-compose.yml
+++ b/projects/licai/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  licai:
+    image: nginx:alpine
+    container_name: licai
+    restart: unless-stopped
+    volumes:
+      # Mount the wealth-products archive — dashboard.html lives at the root
+      - /home/jingtao/finance/wealth-products:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    environment:
+      VIRTUAL_HOST: licai.ai.jingtao.fun
+      VIRTUAL_PORT: 80
+      LETSENCRYPT_HOST: licai.ai.jingtao.fun
+      LETSENCRYPT_EMAIL: jingtao_buaa@icloud.com
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true

--- a/projects/licai/nginx.conf
+++ b/projects/licai/nginx.conf
@@ -1,0 +1,58 @@
+# licai.ai.jingtao.fun — Wealth-products dashboard
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+
+    # Serve dashboard.html as the index
+    index dashboard.html;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    # Disable directory listing
+    autoindex off;
+
+    # Block dotfiles
+    location ~ /\. {
+        deny all;
+        return 404;
+    }
+
+    # Root → dashboard.html
+    location = / {
+        try_files /dashboard.html =404;
+    }
+
+    # Per-product pages — read-only static serving under /<bank>/<code>/
+    # Allow: dashboard.html, index.json (machine-readable), <bank>/<code>/report.html,
+    # <bank>/<code>/chart.svg, and PDFs under <bank>/<code>/pdfs/
+    location = /dashboard.html { try_files $uri =404; }
+    location = /index.json { try_files $uri =404; }
+    location = /README.md { try_files $uri =404; }
+
+    location ~* "^/[a-z]+/[A-Za-z0-9]+/report\.html$" {
+        try_files $uri =404;
+    }
+
+    location ~* "^/[a-z]+/[A-Za-z0-9]+/chart\.svg$" {
+        try_files $uri =404;
+    }
+
+    location ~* "^/[a-z]+/[A-Za-z0-9]+/meta\.json$" {
+        try_files $uri =404;
+    }
+
+    location ~* "^/[a-z]+/[A-Za-z0-9]+/pdfs/.+\.pdf$" {
+        try_files $uri =404;
+    }
+
+    # Block everything else (raw data files, build scripts, etc.)
+    location / {
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new docker service exposing the wealth-products research archive at **https://licai.ai.jingtao.fun**.

## What it serves

- Root `/` → `dashboard.html` (aggregate dashboard, auto-refreshed on every archive update)
- `/<bank>/<code>/report.html` → per-product full reports
- `/<bank>/<code>/chart.svg` → net-value charts
- `/<bank>/<code>/meta.json` → structured product metadata
- `/<bank>/<code>/pdfs/*.pdf` → official disclosure PDFs
- `/index.json` → machine-readable index

Blocked at nginx level: raw API dumps (`data.json`/`nv_full.json`/`reports.json`), build scripts, `share_url.txt` back-pointers.

## Architecture

- `nginx:alpine` container, read-only bind-mount of `~/finance/wealth-products/` (managed outside the repo — accumulates research artifacts that don't belong in version control)
- nginx-proxy + letsencrypt-companion for automatic HTTPS via `VIRTUAL_HOST` / `LETSENCRYPT_HOST` env vars (same pattern as existing `share-hosting` service)
- Whitelist regex per location to ensure only intended files are served

## Why a dedicated subdomain?

The archive previously lived at a UUID-only URL on `share-hosting` (`share.ai.jingtao.fun/<uuid>.html`). Per-product 报告 stay on share-hosting for ad-hoc sharing, but the **aggregate dashboard deserves a memorable, dedicated URL** since it's a permanent, growing resource that Jingtao bookmarks. Future stock / 基金 / 保险 dashboards will follow the same pattern (e.g. `gupiao.ai.jingtao.fun`, `baoxian.ai.jingtao.fun`).

## Test plan

- [x] `docker compose config` validates
- [x] Container starts and shows up in nginx-proxy registration
- [x] `curl -sI https://licai.ai.jingtao.fun/` returns 200 (cert auto-issued)
- [x] Per-product paths return 200 (`report.html`, `chart.svg`, `meta.json`, PDFs)
- [x] Blocked paths return 404 (`data.json`, build scripts, `share_url.txt`)
- [x] Existing `share-hosting` UUID mirror still works

## Related

- The build pipeline + meta.json schema is documented in the `cn-bank-wealth-products` skill (lives in `~/.hermes/skills/`, not in this repo)
- Archive scripts `build_dashboard.py` and `archive_product.py` live in `~/finance/wealth-products/` alongside the data
