### PR TITLE
feat(share-hosting): formalize UUID-only file share service

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -34,6 +34,7 @@ projects/
 | [experience-manager](experience-manager/) | `ems.ai.jingtao.fun` | AI agent experience storage and semantic search (EMS) |
 | [ai-task-engine](ai-task-engine/) | `localhost:3200` | Workflow engine for AI task orchestration with Discord, EMS, and OpenClaw integration |
 | [licai](licai/) | `licai.${S_DOMAIN}` | Dashboard + per-product browser for the wealth-products research archive at `~/finance/wealth-products/` |
+| [share-hosting](share-hosting/) | `share.${S_DOMAIN}` | UUID-only static file share for ad-hoc HTML/PDF/MD/TXT — unguessable paths, scan-resistant |
 
 ## Adding a New Project
 

--- a/projects/share-hosting/README.md
+++ b/projects/share-hosting/README.md
@@ -1,0 +1,49 @@
+# share-hosting — UUID-only static file share
+
+Self-hosted nginx serving files at **https://share.ai.jingtao.fun** with UUID-v4 path whitelisting and anti-scan guards.
+
+## Why
+
+For sharing one-off HTML reports / PDFs / markdown without exposing them via a guessable URL or third-party service. The UUID v4 path provides ~122 bits of entropy — brute-force scanning is infeasible.
+
+## What it serves
+
+- Only paths matching `^/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(html|pdf|md|txt)$`
+- Everything else → 404 (including `/`, `/index.html`, dotfiles, uppercase UUIDs, non-whitelist extensions)
+- Directory listing off
+
+## Architecture
+
+| Component | Value |
+|---|---|
+| Image | `nginx:alpine` |
+| Data mount | `/data_static/share-hosting/` → `/usr/share/nginx/html` (read-only) |
+| Network | `nginx-proxy` bridge |
+| TLS / vhost | `nginx-proxy` + `nginx-proxy-acme` via `VIRTUAL_HOST` env var |
+| Subdomain | `share.ai.jingtao.fun` |
+
+## Deploy
+
+```bash
+cd ~/ai-learn/projects/share-hosting
+docker compose up -d
+```
+
+First request after fresh deploy may take 5-30s while letsencrypt-companion fetches a cert.
+
+## Usage
+
+```python
+import uuid, shutil, os
+uid = str(uuid.uuid4())
+dst = f"/data_static/share-hosting/{uid}.html"
+shutil.copy(local_path, dst)
+os.chmod(dst, 0o644)  # nginx runs as a different user — must be world-readable
+print(f"https://share.ai.jingtao.fun/{uid}.html")
+```
+
+See `~/.hermes/skills/devops/share-hosting/SKILL.md` for the full agent workflow.
+
+## Related
+
+- **licai** (`licai.ai.jingtao.fun`): Dedicated dashboard subdomain for wealth-products archive (same nginx pattern, structured paths instead of UUID).

--- a/projects/share-hosting/docker-compose.yml
+++ b/projects/share-hosting/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  share-hosting:
+    image: nginx:alpine
+    container_name: share-hosting
+    restart: unless-stopped
+    volumes:
+      - /data_static/share-hosting:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    environment:
+      VIRTUAL_HOST: share.ai.jingtao.fun
+      VIRTUAL_PORT: 80
+      LETSENCRYPT_HOST: share.ai.jingtao.fun
+      LETSENCRYPT_EMAIL: jingtao_buaa@icloud.com
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true

--- a/projects/share-hosting/nginx.conf
+++ b/projects/share-hosting/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    server_tokens off;
+
+    # No directory listing — prevents scanning
+    autoindex off;
+
+    # Block root and any directory request — no enumeration
+    location = / {
+        return 404;
+    }
+
+    # Whitelist file types only (UUID paths required)
+    location ~* "^/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(html|pdf|md|txt)$" {
+        add_header Cache-Control "private, max-age=3600";
+        add_header X-Content-Type-Options "nosniff";
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header Referrer-Policy "no-referrer";
+        try_files $uri =404;
+    }
+
+    # Everything else: 404 (no info leakage)
+    location / {
+        return 404;
+    }
+
+    # Don't serve hidden files
+    location ~ /\. {
+        deny all;
+        return 404;
+    }
+}


### PR DESCRIPTION
## Summary

The `share-hosting` service (https://share.ai.jingtao.fun) has been running in production since 2026-05-30 but was never committed to the repo. This PR fixes that historical gap — service definition, nginx config, and docs go into version control.

## What's added

- `projects/share-hosting/docker-compose.yml` — nginx:alpine + nginx-proxy integration
- `projects/share-hosting/nginx.conf` — UUID-v4 path whitelist + scan-resistant 404s
- `projects/share-hosting/README.md` — usage / deploy / security model
- `projects/README.md` table row

## Security model (re-verified against running service)

| Request | Result |
|---|---|
| `GET /<uuid>.html` (correct UUID v4 + whitelist ext) | 200 |
| `GET /`, `GET /index.html`, `GET /report.html` | 404 |
| Uppercase UUID, non-whitelist ext (`.exe` etc.) | 404 |
| Dotfiles (`/.env`) | 404 |
| Directory listing | off |

UUID v4 = ~122 bits of entropy → brute-force scan infeasible.

## Why now

Per Jingtao's direction (2026-06-13): "This repo's goal is accumulation, you're responsible for it." Closing infrastructure gaps so the running stack is fully reproducible from the repo, not from runtime state.

## Test plan

- [x] Verified all files at `projects/share-hosting/` match the live running `share-hosting` container's config
- [x] No secrets in committed files (Gitleaks pre-commit hook passed)
- [x] LETSENCRYPT_EMAIL is the same public address used in other services
