### PR TITLE
feat(licai): v2 — multi-asset-class investment hub

### DIFF
--- a/projects/licai/README.md
+++ b/projects/licai/README.md
@@ -1,39 +1,52 @@
-# licai — Wealth-Products Dashboard
+# licai — Investment Research Hub
 
-Dedicated subdomain for Jingtao's wealth-management research archive.
+Dedicated subdomain for Jingtao's investment-research archive across all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密 / ...).
 
 **URL**: https://licai.ai.jingtao.fun
 
 ## What it serves
 
-- `/` → `dashboard.html` — the aggregate dashboard (auto-refreshed on every `build_dashboard.py` run)
-- `/<bank>/<code>/report.html` — individual product reports (e.g. `/icbc/25G2488A/report.html`)
-- `/<bank>/<code>/chart.svg` — net-value charts
-- `/<bank>/<code>/meta.json` — structured product metadata
-- `/<bank>/<code>/pdfs/*.pdf` — official disclosure PDFs
+- `/` → `dashboard.html` — tab-grouped aggregate dashboard (auto-refreshed on every `build_dashboard.py` run)
+- `/<asset_class>/<owner>/<code>/report.html` — per-report full reports
+  - `asset_class` ∈ `wealth` | `stock` | `insurance` | `fund` | `bond` | `crypto` | `other`
+  - `owner` = bank/market/insurer slug, lowercase alnum + hyphen
+  - `code` = product code, alnum
+- `/<asset_class>/<owner>/<code>/card.json` — structured dashboard card data
+- `/<asset_class>/<owner>/<code>/meta.json` — structured product metadata (per-skill schema)
+- `/<asset_class>/<owner>/<code>/chart.svg` — charts
+- `/<asset_class>/<owner>/<code>/pdfs/*.pdf` — official disclosure PDFs
+- `/<asset_class>/<owner>/<code>/assets/*.{png,jpg,svg,webp}` — skill-specific images
+- `/index.json` — machine-readable aggregate summary
+- `/README.md` — archive documentation
 
 Hidden from web (server-side raw data only):
 - `data.json` / `nv_full.json` / `reports.json` — raw API dumps
-- `*.py` — build scripts
+- `*.py` — build/register scripts
 - `share_url.txt` — back-pointers to share-hosting
+- `.history/` — version-history snapshots (internal use)
 
 ## Data source
 
-Read-only mount of `/home/jingtao/finance/wealth-products/`. The dashboard regenerates on every `build_dashboard.py` run; nginx serves the freshly-written file with no restart needed.
+Read-only mount of `/home/jingtao/finance/reports/`. The dashboard regenerates on every `register_report.py` call (which any analysis skill invokes after publishing). nginx serves the freshly-written file with no restart needed.
 
-## Deploy
+## Architecture
+
+- **Concurrency-safe**: each report lives in its own dir, dashboard build is pure scan. Multiple skills can register simultaneously.
+- **URL stable**: nginx whitelist regex on path means the URL contract is enforced — re-running an analysis with the same `(asset_class, owner, code)` reuses the URL.
+- **Overwrite semantics**: re-analysis replaces in place (typically what you want — show latest verdict). `--keep-history` flag preserves old version under `.history/`.
+
+## Deploy / update
 
 ```bash
 cd ~/ai-learn/projects/licai
-docker compose up -d
+docker compose down && docker compose up -d
 ```
 
-First request after fresh deploy may take 5-30s while letsencrypt-companion fetches a cert. Watch with:
-```bash
-docker logs -f nginx-proxy-acme | grep licai
-```
+First request after fresh deploy may take 5-30s while letsencrypt-companion fetches a cert.
 
 ## Related
 
-- **share-hosting** (`share.ai.jingtao.fun`): UUID-only file share for ad-hoc reports
-- **licai** (this): Dedicated dashboard + per-product browser for the wealth-products archive
+- **share-hosting** (`share.ai.jingtao.fun`): UUID-only file share for ad-hoc reports — complements this with unstructured paths
+- **investment-research-registry** Hermes skill: the registration contract that all analysis skills follow
+- **cn-bank-wealth-products / cn-stock-financial-analysis / insurance-brochure-analysis** Hermes skills: analysis skills that populate this dashboard
+

--- a/projects/licai/docker-compose.yml
+++ b/projects/licai/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: licai
     restart: unless-stopped
     volumes:
-      # Mount the wealth-products archive — dashboard.html lives at the root
-      - /home/jingtao/finance/wealth-products:/usr/share/nginx/html:ro
+      # Mount the unified investment-research archive
+      - /home/jingtao/finance/reports:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     environment:
       VIRTUAL_HOST: licai.ai.jingtao.fun

--- a/projects/licai/nginx.conf
+++ b/projects/licai/nginx.conf
@@ -1,12 +1,13 @@
-# licai.ai.jingtao.fun — Wealth-products dashboard
+# licai.ai.jingtao.fun — Investment-research hub
+# Serves dashboard.html (aggregate) + per-report assets under
+# /<asset_class>/<owner>/<code>/... where asset_class ∈ {wealth, stock,
+# insurance, fund, bond, crypto, other}.
 
 server {
     listen 80;
     server_name _;
 
     root /usr/share/nginx/html;
-
-    # Serve dashboard.html as the index
     index dashboard.html;
 
     # Security headers
@@ -17,7 +18,7 @@ server {
     # Disable directory listing
     autoindex off;
 
-    # Block dotfiles
+    # Block dotfiles (including the .history/ snapshot dirs — internal use only)
     location ~ /\. {
         deny all;
         return 404;
@@ -28,30 +29,48 @@ server {
         try_files /dashboard.html =404;
     }
 
-    # Per-product pages — read-only static serving under /<bank>/<code>/
-    # Allow: dashboard.html, index.json (machine-readable), <bank>/<code>/report.html,
-    # <bank>/<code>/chart.svg, and PDFs under <bank>/<code>/pdfs/
+    # Top-level utility files
     location = /dashboard.html { try_files $uri =404; }
     location = /index.json { try_files $uri =404; }
     location = /README.md { try_files $uri =404; }
 
-    location ~* "^/[a-z]+/[A-Za-z0-9]+/report\.html$" {
+    # Per-report assets: /<asset_class>/<owner>/<code>/...
+    # asset_class ∈ wealth|stock|insurance|fund|bond|crypto|other (lowercase a-z)
+    # owner ∈ alnum + hyphen (e.g. icbc, cmb, sh, sz, china-life)
+    # code ∈ alnum (e.g. 25G2488A, 600519)
+
+    # Whitelist: card.json (used by external tools / debugging)
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/card\.json$" {
         try_files $uri =404;
     }
 
-    location ~* "^/[a-z]+/[A-Za-z0-9]+/chart\.svg$" {
+    # Whitelist: report.html
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/report\.html$" {
         try_files $uri =404;
     }
 
-    location ~* "^/[a-z]+/[A-Za-z0-9]+/meta\.json$" {
+    # Whitelist: chart.svg
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/chart\.svg$" {
         try_files $uri =404;
     }
 
-    location ~* "^/[a-z]+/[A-Za-z0-9]+/pdfs/.+\.pdf$" {
+    # Whitelist: meta.json (structured product metadata, per skill schema)
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/meta\.json$" {
         try_files $uri =404;
     }
 
-    # Block everything else (raw data files, build scripts, etc.)
+    # Whitelist: any PDF under pdfs/
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/pdfs/.+\.pdf$" {
+        try_files $uri =404;
+    }
+
+    # Whitelist: assets/ subdirectory for arbitrary skill-specific images/svgs
+    # (skill can put extra report assets here; only common image types served)
+    location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/assets/.+\.(png|jpe?g|svg|webp)$" {
+        try_files $uri =404;
+    }
+
+    # Block everything else (raw data dumps, build scripts, share_url.txt, etc.)
     location / {
         return 404;
     }


### PR DESCRIPTION
## Summary

Upgrades `licai.ai.jingtao.fun` from a wealth-products-only dashboard to a **unified investment-research hub** covering all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密).

## URL contract change

| | Before (v1) | After (v2) |
|---|---|---|
| Per-report path | `/<bank>/<code>/report.html` | `/<asset_class>/<owner>/<code>/report.html` |
| Example | `/icbc/25G2488A/report.html` | `/wealth/icbc/25G2488A/report.html` |
| Whitelisted files | report.html, chart.svg, meta.json, pdfs/*.pdf | + card.json, + assets/*.{png,jpg,svg,webp} |

The new path structure enables clean co-existence of e.g. `/wealth/icbc/25G2488A` and `/stock/sh/600519` and `/insurance/china-life/xyz`.

## Architecture

- **Concurrency-safe**: each report has its own dir + own `card.json`. No central index lock. Multiple analysis skills can register simultaneously.
- **Tab-based dashboard**: 理财 / 股票 / 保险 / 基金 / 债券 / 加密 / 其他 (only non-empty + 4 core always shown)
- **Re-analysis overwrites**: re-running registration for the same `(asset_class, owner, code)` replaces in place (typical: show latest verdict). Optional `--keep-history` preserves old version under `.history/`.
- **Registration contract**: documented in the new `investment-research-registry` Hermes skill. All analysis skills (`cn-bank-wealth-products`, `cn-stock-financial-analysis`, `insurance-brochure-analysis`) updated to register via this contract.

## What changed in this repo

- `projects/licai/docker-compose.yml`: mount repointed (`/home/jingtao/finance/wealth-products` → `/home/jingtao/finance/reports`)
- `projects/licai/nginx.conf`: regex updated for new path structure + new file types (card.json, assets/)
- `projects/licai/README.md`: rewritten

## Backing data

`~/finance/reports/` (managed outside repo, like the previous `wealth-products/`). Existing `25G2488A` report migrated to `~/finance/reports/wealth/icbc/25G2488A/`. The old `~/finance/wealth-products/` is archived at `~/finance/wealth-products.deprecated-2026-06-13/` (safe to delete in a few weeks).

## Test plan

- [x] `docker compose down && up -d` succeeds, container healthy
- [x] `curl -sI https://licai.ai.jingtao.fun/` returns 200 (cert reused)
- [x] `curl -sI https://licai.ai.jingtao.fun/wealth/icbc/25G2488A/report.html` returns 200
- [x] `curl -sI https://licai.ai.jingtao.fun/wealth/icbc/25G2488A/card.json` returns 200
- [x] `curl -sI https://licai.ai.jingtao.fun/index.json` returns 200
- [x] Blocked paths return 404: nv_full.json / build_dashboard.py / register_report.py / share_url.txt / .history/*
- [x] Dashboard renders with tab bar (理财 active by default, other tabs visible but 0)
- [x] Mobile breakpoints verified (≤720 / ≤480 / ≤360)
- [x] No secrets in committed files (Gitleaks passed)
