### PR TITLE
feat(finance): rename licai service to finance (legacy URL 301-redirects)

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -33,7 +33,7 @@ projects/
 | [nav-portal](nav-portal/) | `nav.${S_DOMAIN}` | Navigation dashboard with Docker service auto-discovery |
 | [experience-manager](experience-manager/) | `ems.ai.jingtao.fun` | AI agent experience storage and semantic search (EMS) |
 | [ai-task-engine](ai-task-engine/) | `localhost:3200` | Workflow engine for AI task orchestration with Discord, EMS, and OpenClaw integration |
-| [licai](licai/) | `licai.${S_DOMAIN}` | Dashboard + per-product browser for the wealth-products research archive at `~/finance/wealth-products/` |
+| [finance](finance/) | `finance.${S_DOMAIN}` | Unified investment-research hub — dashboard + per-report browser for `~/finance/reports/` (理财/股票/保险/基金/...); also serves `licai.${S_DOMAIN}` via 301 redirect for legacy URLs |
 | [share-hosting](share-hosting/) | `share.${S_DOMAIN}` | UUID-only static file share for ad-hoc HTML/PDF/MD/TXT — unguessable paths, scan-resistant |
 
 ## Adding a New Project

--- a/projects/finance/README.md
+++ b/projects/finance/README.md
@@ -1,8 +1,9 @@
-# licai — Investment Research Hub
+# finance — Investment Research Hub
 
 Dedicated subdomain for Jingtao's investment-research archive across all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密 / ...).
 
-**URL**: https://licai.ai.jingtao.fun
+**Primary URL**: https://finance.ai.jingtao.fun
+**Legacy URL** (301-redirects to primary): https://licai.ai.jingtao.fun
 
 ## What it serves
 
@@ -35,18 +36,21 @@ Read-only mount of `/home/jingtao/finance/reports/`. The dashboard regenerates o
 - **URL stable**: nginx whitelist regex on path means the URL contract is enforced — re-running an analysis with the same `(asset_class, owner, code)` reuses the URL.
 - **Overwrite semantics**: re-analysis replaces in place (typically what you want — show latest verdict). `--keep-history` flag preserves old version under `.history/`.
 
+## Naming history
+
+Originally deployed as `licai.ai.jingtao.fun` (理财 = wealth management) when the hub only covered bank wealth products. Renamed to `finance.ai.jingtao.fun` on 2026-06-13 once coverage expanded to all asset classes. The legacy hostname does a 301 permanent redirect.
+
 ## Deploy / update
 
 ```bash
-cd ~/ai-learn/projects/licai
+cd ~/ai-learn/projects/finance
 docker compose down && docker compose up -d
 ```
 
-First request after fresh deploy may take 5-30s while letsencrypt-companion fetches a cert.
+First request after fresh deploy may take 5-30s while letsencrypt-companion issues the SAN cert (covers both `finance.*` and `licai.*`).
 
 ## Related
 
 - **share-hosting** (`share.ai.jingtao.fun`): UUID-only file share for ad-hoc reports — complements this with unstructured paths
 - **investment-research-registry** Hermes skill: the registration contract that all analysis skills follow
 - **cn-bank-wealth-products / cn-stock-financial-analysis / insurance-brochure-analysis** Hermes skills: analysis skills that populate this dashboard
-

--- a/projects/finance/docker-compose.yml
+++ b/projects/finance/docker-compose.yml
@@ -1,16 +1,18 @@
 services:
-  licai:
+  finance:
     image: nginx:alpine
-    container_name: licai
+    container_name: finance
     restart: unless-stopped
     volumes:
       # Mount the unified investment-research archive
       - /home/jingtao/finance/reports:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     environment:
-      VIRTUAL_HOST: licai.ai.jingtao.fun
+      # Primary hostname: finance. Legacy: licai (301-redirects to finance — see nginx.conf).
+      # nginx-proxy + acme-companion will request a SAN cert covering both.
+      VIRTUAL_HOST: finance.ai.jingtao.fun,licai.ai.jingtao.fun
       VIRTUAL_PORT: 80
-      LETSENCRYPT_HOST: licai.ai.jingtao.fun
+      LETSENCRYPT_HOST: finance.ai.jingtao.fun,licai.ai.jingtao.fun
       LETSENCRYPT_EMAIL: jingtao_buaa@icloud.com
     networks:
       - nginx-proxy

--- a/projects/finance/nginx.conf
+++ b/projects/finance/nginx.conf
@@ -1,11 +1,22 @@
-# licai.ai.jingtao.fun — Investment-research hub
+# finance.ai.jingtao.fun — Investment-research hub
 # Serves dashboard.html (aggregate) + per-report assets under
 # /<asset_class>/<owner>/<code>/... where asset_class ∈ {wealth, stock,
 # insurance, fund, bond, crypto, other}.
+#
+# Legacy hostname: licai.ai.jingtao.fun — 301-redirects to finance.ai.jingtao.fun
+# (so any existing links keep working).
 
+# ----- Legacy hostname: permanent redirect to finance.* -----
 server {
     listen 80;
-    server_name _;
+    server_name licai.ai.jingtao.fun;
+    return 301 https://finance.ai.jingtao.fun$request_uri;
+}
+
+# ----- Primary hostname: serves the hub -----
+server {
+    listen 80 default_server;
+    server_name finance.ai.jingtao.fun _;
 
     root /usr/share/nginx/html;
     index dashboard.html;
@@ -65,7 +76,6 @@ server {
     }
 
     # Whitelist: assets/ subdirectory for arbitrary skill-specific images/svgs
-    # (skill can put extra report assets here; only common image types served)
     location ~* "^/(wealth|stock|insurance|fund|bond|crypto|other)/[a-z0-9-]+/[A-Za-z0-9]+/assets/.+\.(png|jpe?g|svg|webp)$" {
         try_files $uri =404;
     }


### PR DESCRIPTION
## Summary

Renames the docker service from `licai` to `finance` and migrates the primary URL from `licai.ai.jingtao.fun` to `finance.ai.jingtao.fun`. The legacy hostname keeps working via a 301 permanent redirect.

## Why

`licai` (理财 = wealth management) was accurate when the service only covered bank wealth products. Coverage now spans all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密 / 其他), so the name should match.

## URL contract

| Hostname | Behavior |
|---|---|
| `finance.ai.jingtao.fun` | Primary — serves the hub |
| `licai.ai.jingtao.fun` | 301 permanent redirect to `finance.*` (incl. deep paths like `/wealth/icbc/25G2488A/report.html`) |

Both are covered by a SAN cert from letsencrypt-companion (`LETSENCRYPT_HOST: finance.ai.jingtao.fun,licai.ai.jingtao.fun`).

## What changed in this repo

- `projects/licai/` → `projects/finance/` (git rename, history preserved)
- `container_name`: licai → finance
- `nginx.conf`: added 301-redirect server block for legacy hostname
- README + project table updated

## What changed outside this repo (Hermes side)

All updated to emit `finance.ai.jingtao.fun` as canonical:
- `~/finance/reports/register_report.py` — registry script
- `~/finance/reports/build_dashboard.py` — dashboard footer URL
- `~/finance/reports/wealth/icbc/25G2488A/card.json` — existing report
- 4 SKILL.md files: `cn-bank-wealth-products`, `cn-stock-financial-analysis`, `insurance-brochure-analysis`, `investment-research-registry`

## Test plan

- [x] `curl -sI https://finance.ai.jingtao.fun/` → 200
- [x] `curl -sI https://licai.ai.jingtao.fun/` → 301 → `https://finance.ai.jingtao.fun/`
- [x] `curl -sIL https://licai.ai.jingtao.fun/wealth/icbc/25G2488A/report.html` → 200 (deep redirect works)
- [x] SAN cert covers both hostnames (no cert error)
- [x] No secrets in committed files (Gitleaks passed)
