### PR TITLE
chore(finance): drop licai.ai.jingtao.fun hostname

### DIFF
--- a/projects/finance/README.md
+++ b/projects/finance/README.md
@@ -2,8 +2,7 @@
 
 Dedicated subdomain for Jingtao's investment-research archive across all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密 / ...).
 
-**Primary URL**: https://finance.ai.jingtao.fun
-**Legacy URL** (301-redirects to primary): https://licai.ai.jingtao.fun
+**URL**: https://finance.ai.jingtao.fun
 
 ## What it serves
 
@@ -38,7 +37,7 @@ Read-only mount of `/home/jingtao/finance/reports/`. The dashboard regenerates o
 
 ## Naming history
 
-Originally deployed as `licai.ai.jingtao.fun` (理财 = wealth management) when the hub only covered bank wealth products. Renamed to `finance.ai.jingtao.fun` on 2026-06-13 once coverage expanded to all asset classes. The legacy hostname does a 301 permanent redirect.
+Originally deployed as `licai.ai.jingtao.fun` (理财 = wealth management) when the hub only covered bank wealth products. Renamed to `finance.ai.jingtao.fun` on 2026-06-13 once coverage expanded to all asset classes.
 
 ## Deploy / update
 
@@ -47,7 +46,7 @@ cd ~/ai-learn/projects/finance
 docker compose down && docker compose up -d
 ```
 
-First request after fresh deploy may take 5-30s while letsencrypt-companion issues the SAN cert (covers both `finance.*` and `licai.*`).
+First request after fresh deploy may take 5-30s while letsencrypt-companion issues the cert.
 
 ## Related
 

--- a/projects/finance/docker-compose.yml
+++ b/projects/finance/docker-compose.yml
@@ -8,11 +8,9 @@ services:
       - /home/jingtao/finance/reports:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     environment:
-      # Primary hostname: finance. Legacy: licai (301-redirects to finance — see nginx.conf).
-      # nginx-proxy + acme-companion will request a SAN cert covering both.
-      VIRTUAL_HOST: finance.ai.jingtao.fun,licai.ai.jingtao.fun
+      VIRTUAL_HOST: finance.ai.jingtao.fun
       VIRTUAL_PORT: 80
-      LETSENCRYPT_HOST: finance.ai.jingtao.fun,licai.ai.jingtao.fun
+      LETSENCRYPT_HOST: finance.ai.jingtao.fun
       LETSENCRYPT_EMAIL: jingtao_buaa@icloud.com
     networks:
       - nginx-proxy

--- a/projects/finance/nginx.conf
+++ b/projects/finance/nginx.conf
@@ -2,20 +2,9 @@
 # Serves dashboard.html (aggregate) + per-report assets under
 # /<asset_class>/<owner>/<code>/... where asset_class ∈ {wealth, stock,
 # insurance, fund, bond, crypto, other}.
-#
-# Legacy hostname: licai.ai.jingtao.fun — 301-redirects to finance.ai.jingtao.fun
-# (so any existing links keep working).
 
-# ----- Legacy hostname: permanent redirect to finance.* -----
 server {
     listen 80;
-    server_name licai.ai.jingtao.fun;
-    return 301 https://finance.ai.jingtao.fun$request_uri;
-}
-
-# ----- Primary hostname: serves the hub -----
-server {
-    listen 80 default_server;
     server_name finance.ai.jingtao.fun _;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
## Summary

Removes the legacy `licai.ai.jingtao.fun` hostname per Jingtao's request — `finance.ai.jingtao.fun` is the only URL going forward.

Follow-up to #124 (rename) and #123 (v2 multi-asset-class).

## Changes

- `docker-compose.yml`: VIRTUAL_HOST / LETSENCRYPT_HOST drop the licai SAN entry (cert will be reissued as finance-only on next ACME renewal)
- `nginx.conf`: removed the 301-redirect server block for the legacy hostname
- `README.md`: removed 'Primary URL / Legacy URL' dual mention; kept the 'Naming history' note for the historical record

## Test plan

- [x] Container restart succeeded
- [x] `curl -sI https://finance.ai.jingtao.fun/` → 200
- [x] `curl -sI https://licai.ai.jingtao.fun/` → connection failure (cert no longer covers this hostname — intended)
- [x] nginx-proxy default.conf no longer references licai
