### PR TITLE
feat: add generic content hub registry

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -33,7 +33,8 @@ projects/
 | [nav-portal](nav-portal/) | `nav.${S_DOMAIN}` | Navigation dashboard with Docker service auto-discovery |
 | [experience-manager](experience-manager/) | `ems.ai.jingtao.fun` | AI agent experience storage and semantic search (EMS) |
 | [ai-task-engine](ai-task-engine/) | `localhost:3200` | Workflow engine for AI task orchestration with Discord, EMS, and OpenClaw integration |
-| [finance](finance/) | `finance.${S_DOMAIN}` | Unified investment-research hub — dashboard + per-report browser for `~/finance/reports/` (理财/股票/保险/基金/...); also serves `licai.${S_DOMAIN}` via 301 redirect for legacy URLs |
+| [finance](finance/) | `finance.${S_DOMAIN}` | Unified investment-research hub — dashboard + per-report browser for `~/finance/reports/` (理财/股票/保险/基金/...) |
+| [content-hub](content-hub/) | `hub.${S_DOMAIN}` | Generic two-level content registry: category directory → searchable category dashboards → canonical artifact links |
 | [share-hosting](share-hosting/) | `share.${S_DOMAIN}` | UUID-only static file share for ad-hoc HTML/PDF/MD/TXT — unguessable paths, scan-resistant |
 
 ## Adding a New Project

--- a/projects/content-hub/README.md
+++ b/projects/content-hub/README.md
@@ -1,0 +1,93 @@
+# Content Hub
+
+A generic two-level navigation and registration platform for Jingtao's research, learning, and decision artifacts.
+
+**Production URL:** https://hub.ai.jingtao.fun
+
+## Information architecture
+
+1. **Level 1 — category directory:** `/` lists every registered category with its item count and latest update.
+2. **Level 2 — category dashboard:** `/categories/<category-id>/` lists all registered items in that category using a consistent searchable card layout.
+3. **Primary artifacts:** item cards link to the canonical report, tool, or document URL. The hub stores public navigation metadata, not report bodies.
+
+Examples of categories:
+
+- `investment-research` — wealth, stock, fund, insurance, and other financial research
+- `skill-learning` — bilingual Skill Learning reports
+- future categories can be added without changing the renderer or Nginx configuration
+
+## Registry API
+
+One CLI owns both registration levels:
+
+```bash
+# Register or update a category
+python3 ~/ai-learn/projects/content-hub/register.py category \
+  --card-json /path/to/category.json
+
+# Register or update an item inside an existing category
+python3 ~/ai-learn/projects/content-hub/register.py item \
+  --card-json /path/to/item.json
+```
+
+Category registration is idempotent by `category_id`. Item registration is idempotent by `(category_id, item_id)`. An item cannot be registered before its category exists.
+
+## Atomic publication model
+
+```text
+~/content-hub/
+├── current -> .releases/<release-id>
+├── .registry.lock
+└── .releases/<release-id>/
+    ├── _registry/                         # private source of truth; blocked by Nginx
+    │   ├── categories/<category-id>.json
+    │   └── items/<category-id>/<item-id>.json
+    ├── dashboard.html                     # level-1 category directory
+    ├── index.json
+    └── categories/<category-id>/
+        ├── category.json
+        ├── index.html                     # level-2 category dashboard
+        ├── index.json
+        └── items/<item-id>/card.json
+```
+
+Every registration:
+
+1. acquires one OS file lock;
+2. loads and revalidates the current private registry;
+3. writes complete category/item state into a new staging release;
+4. renders all level-1 and level-2 pages;
+5. atomically swaps the public `current` symlink.
+
+Nginx readers therefore see either the complete old release or the complete new release. `build_site.py` refuses to mutate the active release directly.
+
+## Public whitelist
+
+Nginx serves only:
+
+- `/`, `/dashboard.html`, `/index.json`
+- `/categories/<category-id>/`
+- `/categories/<category-id>/{index.html,index.json,category.json}`
+- `/categories/<category-id>/items/<item-id>/card.json`
+
+Private `_registry/`, `.releases/`, lock files, scripts, temporary files, and unknown paths return 404.
+
+## Test
+
+```bash
+cd ~/ai-learn/projects/content-hub
+python3 -m unittest -v tests/test_registry.py
+python3 -m py_compile register.py build_site.py registry_schema.py
+docker run --rm \
+  -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+  nginx:alpine nginx -t
+```
+
+## Deploy
+
+```bash
+mkdir -p ~/content-hub
+cd ~/ai-learn/projects/content-hub
+docker compose up -d
+curl -fsSI https://hub.ai.jingtao.fun/
+```

--- a/projects/content-hub/build_site.py
+++ b/projects/content-hub/build_site.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Render the generic two-level content navigation site."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from registry_schema import parse_published_at, validate_category, validate_item
+
+DEFAULT_ARCHIVE = Path.home() / "content-hub"
+
+
+@dataclass
+class RenderedSite:
+    root_html: str
+    root_index: dict
+    category_html: dict[str, str]
+    category_index: dict[str, dict]
+
+
+def esc(value: object) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def safe_url(value: str) -> str:
+    from registry_schema import ValidationError, _https_url
+
+    try:
+        _https_url("URL", value)
+    except ValidationError:
+        return "#"
+    return esc(value)
+
+
+BASE_CSS = """
+:root{--bg:#f3efe7;--paper:#fffdf9;--ink:#25211d;--muted:#716960;--line:#ddd2c5;--accent:#b65438;--accent-soft:#f4dfd7;--shadow:0 18px 48px rgba(67,52,37,.09)}
+*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;line-height:1.65;-webkit-text-size-adjust:100%;text-size-adjust:100%}a{color:inherit}button,input{font:inherit}.page{width:min(1180px,100%);margin:auto;padding:34px 24px 72px}.hero{position:relative;overflow:hidden;padding:52px clamp(24px,6vw,72px);background:var(--paper);border:1px solid var(--line);border-radius:28px;box-shadow:var(--shadow)}.eyebrow{color:var(--accent);font-size:.76rem;font-weight:800;letter-spacing:.15em;text-transform:uppercase}h1{margin:.35rem 0 .8rem;font-family:Georgia,"Noto Serif SC",serif;font-size:clamp(2.4rem,7vw,5.2rem);font-weight:600;line-height:1;letter-spacing:-.045em;text-wrap:balance}.lede{max-width:760px;margin:0;color:var(--muted);font-size:clamp(1rem,2vw,1.16rem)}.summary-stats{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:30px}.summary-stat{padding:14px 16px;background:#f7f2eb;border:1px solid #e8ddd1;border-radius:14px}.summary-stat b{display:block;color:var(--accent);font-family:Georgia,"Noto Serif SC",serif;font-size:1.7rem}.summary-stat span{color:var(--muted);font-size:.76rem}.section-head{display:flex;justify-content:space-between;align-items:end;gap:16px;margin:30px 3px 16px}.section-head h2{margin:0;font-family:Georgia,"Noto Serif SC",serif;font-size:1.65rem}.section-head span{color:var(--muted);font-size:.82rem}.category-grid,.item-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px}.category-card,.item-card{min-width:0;background:var(--paper);border:1px solid var(--line);border-radius:20px;box-shadow:0 9px 28px rgba(67,52,37,.055)}.category-card{position:relative;overflow:hidden;padding:26px;min-height:275px;display:flex;flex-direction:column}.category-card::after{content:attr(data-icon);position:absolute;right:-12px;bottom:-30px;font-size:9rem;opacity:.055;filter:grayscale(1)}.category-top,.item-top{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}.category-icon{font-size:2rem}.pill{padding:5px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-size:.68rem;font-weight:800;letter-spacing:.04em;text-transform:uppercase}.category-card h3,.item-card h2{margin:18px 0 4px;font-family:Georgia,"Noto Serif SC",serif;font-size:clamp(1.55rem,3vw,2rem);line-height:1.15;overflow-wrap:anywhere}.subtitle{margin:0;color:var(--accent);font-size:.82rem;font-weight:700}.description,.item-summary{color:#4c463f;line-height:1.68}.category-meta{display:flex;flex-wrap:wrap;gap:8px 18px;margin-top:auto;padding-top:18px;color:var(--muted);font-size:.78rem}.category-link,.primary-link{position:relative;z-index:1;min-height:44px;display:inline-flex;align-items:center;justify-content:center;margin-top:18px;padding:0 16px;border-radius:11px;background:var(--accent);color:#fff;text-decoration:none;font-weight:750}.breadcrumb{display:flex;gap:8px;align-items:center;margin:0 0 18px;color:var(--muted);font-size:.84rem}.breadcrumb a{color:var(--accent);text-decoration:none}.controls{position:sticky;top:0;z-index:20;display:flex;gap:10px;margin:24px 0 16px;padding:10px;background:rgba(243,239,231,.94);border:1px solid var(--line);border-radius:16px;backdrop-filter:blur(12px)}.controls input{width:100%;min-height:46px;padding:0 14px;border:1px solid var(--line);border-radius:11px;background:var(--paper);outline:none}.controls input:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(182,84,56,.12)}.item-card{display:flex;flex-direction:column;padding:24px}.item-path{margin:0;color:var(--muted);font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:.72rem;overflow-wrap:anywhere}.badges{display:flex;flex-wrap:wrap;justify-content:flex-end;gap:6px}.item-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(100px,1fr));gap:8px;margin-top:16px;padding:12px;background:#f7f3ed;border-radius:12px}.item-stat b{display:block;color:var(--ink);font-size:.95rem;overflow-wrap:anywhere}.item-stat span,.item-stat small{display:block;color:var(--muted);font-size:.69rem}.highlights{margin:15px 0 0;padding:13px 15px 13px 31px;background:#f6f1ea;border-radius:12px;font-size:.86rem}.item-meta{display:flex;flex-wrap:wrap;gap:7px 14px;margin-top:auto;padding-top:17px;color:var(--muted);font-size:.73rem}.actions{display:flex;gap:10px;margin-top:16px}.actions a{min-height:44px;display:inline-flex;align-items:center;justify-content:center;border-radius:11px;text-decoration:none;font-weight:750}.actions .primary-link{flex:1;margin:0}.source-link{padding:0 14px;border:1px solid var(--line);color:var(--accent)}.empty{display:none;padding:70px 20px;text-align:center;color:var(--muted);background:var(--paper);border:1px dashed var(--line);border-radius:20px}footer{margin-top:34px;color:var(--muted);text-align:center;font-size:.78rem}.accent-teal{--accent:#245e57;--accent-soft:#e3f0ed}.accent-blue{--accent:#1765a8;--accent-soft:#e2edf8}.accent-purple{--accent:#6d52a8;--accent-soft:#ece7f6}.accent-amber{--accent:#9a6424;--accent-soft:#f6ead6}.accent-green{--accent:#347354;--accent-soft:#e3f0e8}
+@media(max-width:760px){.page{padding:18px 12px 56px}.hero{padding:34px 24px;border-radius:20px}.category-grid,.item-grid{grid-template-columns:1fr}.summary-stats{grid-template-columns:repeat(2,1fr)}}@media(max-width:480px){.page{padding:8px 8px 42px}.hero{padding:28px 19px;border-radius:16px}h1{font-size:2.4rem}.summary-stats{grid-template-columns:1fr 1fr;gap:8px}.category-card,.item-card{padding:19px;border-radius:16px}.actions{flex-direction:column}.actions a{width:100%}}@media(max-width:360px){.summary-stats{grid-template-columns:1fr}}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition:none!important}}
+"""
+
+
+def _accent_class(accent: str) -> str:
+    return "" if accent == "terracotta" else f" accent-{esc(accent)}"
+
+
+def _category_card(category: dict, item_count: int, latest: str) -> str:
+    category_id = esc(category["category_id"])
+    return f"""<article class="category-card{_accent_class(category['accent'])}" data-icon="{esc(category['icon'])}">
+<div class="category-top"><span class="category-icon">{esc(category['icon'])}</span><span class="pill">{item_count} {esc(category['item_label'])}</span></div>
+<h3>{esc(category['title'])}</h3><p class="subtitle">{esc(category['subtitle'])}</p><p class="description">{esc(category['description'])}</p>
+<div class="category-meta"><span>最近更新 {esc(latest or '—')}</span><span>来源 {esc(category['source_skill'])}</span></div>
+<a class="category-link" href="/categories/{category_id}/">进入分类 <span aria-hidden="true">→</span></a></article>"""
+
+
+def _item_card(item: dict, accent: str) -> str:
+    badges = "".join(f'<span class="pill">{esc(value)}</span>' for value in item["badges"])
+    stats = "".join(
+        f'<div class="item-stat"><span>{esc(stat["label"])}</span><b>{esc(stat["value"])}</b><small>{esc(stat["sub"])}</small></div>'
+        for stat in item["stats"]
+    )
+    highlights = "".join(f"<li>{esc(value)}</li>" for value in item["highlights"])
+    tags = " · ".join(esc(tag) for tag in item["tags"])
+    search_text = " ".join(
+        [item["title"], item["subtitle"], item["summary"], *item["highlights"], *item["tags"]]
+    ).lower()
+    source_action = (
+        f'<a class="source-link" href="{safe_url(item["source_url"])}" target="_blank" rel="noopener">来源</a>'
+        if item["source_url"]
+        else ""
+    )
+    return f"""<article class="item-card{_accent_class(accent)}" data-search="{esc(search_text)}">
+<div class="item-top"><span class="pill">{esc(item['published_at'][:10])}</span><div class="badges">{badges}</div></div>
+<h2>{esc(item['title'])}</h2><p class="item-path">{esc(item['subtitle'])}</p><p class="item-summary">{esc(item['summary'])}</p>
+{f'<div class="item-stats">{stats}</div>' if stats else ''}{f'<ul class="highlights">{highlights}</ul>' if highlights else ''}
+<div class="item-meta"><span>{tags or '未标注标签'}</span><span>{esc(item['source_skill'])}</span></div>
+<div class="actions"><a class="primary-link" href="{safe_url(item['primary_url'])}" target="_blank" rel="noopener">打开内容 <span aria-hidden="true">→</span></a>{source_action}</div></article>"""
+
+
+def _document(title: str, body: str, accent: str = "terracotta") -> str:
+    return f"""<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover"><meta name="description" content="Jingtao 的通用内容导航与注册中心"><title>{esc(title)}</title><style>{BASE_CSS}</style></head><body class="{_accent_class(accent).strip()}"><main class="page">{body}</main></body></html>"""
+
+
+def build_site(categories: list[dict], items: list[dict]) -> RenderedSite:
+    categories = [validate_category(card) for card in categories]
+    items = [validate_item(card) for card in items]
+    by_id = {card["category_id"]: card for card in categories}
+    if len(by_id) != len(categories):
+        raise ValueError("duplicate category_id")
+    item_identities = [(item["category_id"], item["item_id"]) for item in items]
+    if len(set(item_identities)) != len(item_identities):
+        raise ValueError("duplicate item identity")
+    for item in items:
+        if item["category_id"] not in by_id:
+            raise ValueError(f"orphan item category: {item['category_id']}")
+    ordered_categories = sorted(categories, key=lambda card: (card["sort_order"], card["title"].lower()))
+    items_by_category = {category_id: [] for category_id in by_id}
+    for item in items:
+        items_by_category[item["category_id"]].append(item)
+    for category_items in items_by_category.values():
+        category_items.sort(key=lambda card: parse_published_at(card["published_at"]), reverse=True)
+
+    category_cards = []
+    category_summaries = []
+    category_html: dict[str, str] = {}
+    category_index: dict[str, dict] = {}
+    for category in ordered_categories:
+        category_id = category["category_id"]
+        category_items = items_by_category[category_id]
+        latest = category_items[0]["published_at"][:10] if category_items else ""
+        category_cards.append(_category_card(category, len(category_items), latest))
+        summary = dict(category)
+        summary.update(
+            {
+                "item_count": len(category_items),
+                "latest_at": latest or None,
+                "category_url": f"https://hub.ai.jingtao.fun/categories/{category_id}/",
+            }
+        )
+        category_summaries.append(summary)
+        cards_markup = "\n".join(_item_card(item, category["accent"]) for item in category_items)
+        body = f"""<nav class="breadcrumb"><a href="/">全部分类</a><span>/</span><span>{esc(category['title'])}</span></nav>
+<header class="hero{_accent_class(category['accent'])}"><div class="eyebrow">{esc(category['icon'])} {esc(category['subtitle'])}</div><h1>{esc(category['title'])}</h1><p class="lede">{esc(category['description'])}</p><div class="summary-stats"><div class="summary-stat"><b>{len(category_items)}</b><span>{esc(category['item_label'])}</span></div><div class="summary-stat"><b>{esc(latest or '—')}</b><span>最近更新</span></div><div class="summary-stat"><b>{len({tag for item in category_items for tag in item['tags']})}</b><span>内容标签</span></div></div></header>
+<section class="controls"><input id="search" type="search" placeholder="搜索标题、摘要、标签或关键内容…" autocomplete="off"></section><div class="section-head"><h2>分类内容</h2><span id="result-count">{len(category_items)} 项</span></div><section class="item-grid" id="item-grid">{cards_markup}</section><div class="empty" id="empty">没有匹配的内容。</div><footer>Category: {esc(category_id)} · Content Hub for Jingtao</footer>
+<script>(()=>{{const cards=[...document.querySelectorAll('.item-card')],input=document.getElementById('search'),count=document.getElementById('result-count'),empty=document.getElementById('empty');function apply(){{const q=input.value.trim().toLowerCase();let visible=0;for(const card of cards){{card.hidden=!!q&&!card.dataset.search.includes(q);if(!card.hidden)visible++}}count.textContent=`${{visible}} 项`;empty.style.display=visible?'none':'block'}}input.addEventListener('input',apply)}})();</script>"""
+        category_html[category_id] = _document(
+            f"{category['title']} — Content Hub", body, category["accent"]
+        )
+        category_index[category_id] = {
+            "schema_version": 1,
+            "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "category": summary,
+            "item_count": len(category_items),
+            "items": category_items,
+        }
+
+    root_body = f"""<header class="hero"><div class="eyebrow">Combined content registry / 通用内容注册中心</div><h1>Jingtao Content Hub</h1><p class="lede">统一注册不同类别的研究、学习与决策内容。先选择类别，再进入该类别的专属导航页查看全部条目。</p><div class="summary-stats"><div class="summary-stat"><b>{len(ordered_categories)}</b><span>内容类别</span></div><div class="summary-stat"><b>{len(items)}</b><span>已注册条目</span></div><div class="summary-stat"><b>{sum(bool(values) for values in items_by_category.values())}</b><span>已有内容的类别</span></div></div></header><div class="section-head"><h2>选择一个类别</h2><span>两级导航 · 持续扩展</span></div><section class="category-grid">{''.join(category_cards)}</section><footer>hub.ai.jingtao.fun · Zhang for Jingtao</footer>"""
+    root_index = {
+        "schema_version": 1,
+        "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "category_count": len(ordered_categories),
+        "item_count": len(items),
+        "categories": category_summaries,
+    }
+    return RenderedSite(
+        root_html=_document("Jingtao Content Hub", root_body),
+        root_index=root_index,
+        category_html=category_html,
+        category_index=category_index,
+    )
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def write_public_site(root: Path, categories: list[dict], items: list[dict]) -> None:
+    root = Path(root).expanduser().resolve()
+    candidate_archives = [DEFAULT_ARCHIVE]
+    for parent in (root, *root.parents):
+        if parent.name == ".releases":
+            candidate_archives.append(parent.parent)
+            break
+    for archive in candidate_archives:
+        current = archive / "current"
+        if current.exists():
+            active_release = current.resolve()
+            if root == active_release or active_release in root.parents:
+                raise RuntimeError(
+                    "refusing to mutate the active public release; use register.py"
+                )
+    rendered = build_site(categories, items)
+    root.mkdir(parents=True, exist_ok=True)
+    _atomic_write(root / "dashboard.html", rendered.root_html)
+    _atomic_write(root / "index.json", json.dumps(rendered.root_index, ensure_ascii=False, indent=2) + "\n")
+    categories_by_id = {card["category_id"]: card for card in categories}
+    for category_id, category in categories_by_id.items():
+        category_root = root / "categories" / category_id
+        _atomic_write(category_root / "category.json", json.dumps(category, ensure_ascii=False, indent=2) + "\n")
+        _atomic_write(category_root / "index.html", rendered.category_html[category_id])
+        _atomic_write(category_root / "index.json", json.dumps(rendered.category_index[category_id], ensure_ascii=False, indent=2) + "\n")
+    for item in items:
+        item_path = root / "categories" / item["category_id"] / "items" / item["item_id"] / "card.json"
+        _atomic_write(item_path, json.dumps(item, ensure_ascii=False, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--categories", required=True, type=Path)
+    parser.add_argument("--items", required=True, type=Path)
+    args = parser.parse_args()
+    categories = json.loads(args.categories.read_text(encoding="utf-8"))
+    items = json.loads(args.items.read_text(encoding="utf-8"))
+    write_public_site(args.root, categories, items)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/content-hub/docker-compose.yml
+++ b/projects/content-hub/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  content-hub:
+    image: nginx:alpine
+    container_name: content-hub
+    restart: unless-stopped
+    volumes:
+      - /home/jingtao/content-hub:/usr/share/nginx/archive:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    environment:
+      VIRTUAL_HOST: hub.ai.jingtao.fun
+      VIRTUAL_PORT: 80
+      LETSENCRYPT_HOST: hub.ai.jingtao.fun
+      LETSENCRYPT_EMAIL: jingtao_buaa@icloud.com
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    external: true

--- a/projects/content-hub/nginx.conf
+++ b/projects/content-hub/nginx.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name hub.ai.jingtao.fun _;
+
+    # `current` atomically points to one complete generated release.
+    root /usr/share/nginx/archive/current;
+    index dashboard.html;
+    autoindex off;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+    add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'" always;
+
+    location ~ /\. {
+        deny all;
+        return 404;
+    }
+
+    location = / { try_files /dashboard.html =404; }
+    location = /dashboard.html { try_files $uri =404; }
+    location = /index.json { try_files $uri =404; }
+
+    location ~ "^/categories/([a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)/$" {
+        try_files /categories/$1/index.html =404;
+    }
+    location ~ "^/categories/[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?/(index\.html|index\.json|category\.json)$" {
+        try_files $uri =404;
+    }
+    location ~ "^/categories/[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?/items/[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?/card\.json$" {
+        try_files $uri =404;
+    }
+
+    # Private registry state, releases, scripts, and all unknown paths stay hidden.
+    location / { return 404; }
+}

--- a/projects/content-hub/register.py
+++ b/projects/content-hub/register.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Register categories and items in the generic two-level content hub."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+
+from build_site import write_public_site
+from registry_schema import ValidationError, validate_category, validate_item
+
+DEFAULT_ARCHIVE = Path.home() / "content-hub"
+RegistrationError = ValidationError
+
+
+def _atomic_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _load_current(archive: Path) -> tuple[list[dict], list[dict]]:
+    current = archive / "current"
+    if not current.is_dir():
+        releases = archive / ".releases"
+        if releases.is_dir() and any(path.is_dir() for path in releases.iterdir()):
+            raise RegistrationError(
+                "current release pointer is missing or broken; refusing to rebuild from empty state"
+            )
+        return [], []
+    categories_root = current / "_registry" / "categories"
+    items_root = current / "_registry" / "items"
+    if not categories_root.is_dir() or not items_root.is_dir():
+        raise RegistrationError(
+            "active release is missing private registry state; refusing to rebuild"
+        )
+    categories = [
+        validate_category(json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(categories_root.glob("*.json"))
+    ]
+    items = [
+        validate_item(json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(items_root.glob("*/*.json"))
+    ]
+    try:
+        public_index = json.loads((current / "index.json").read_text(encoding="utf-8"))
+        public_category_ids = {
+            entry["category_id"] for entry in public_index["categories"]
+        }
+        public_categories = [
+            validate_category(json.loads(path.read_text(encoding="utf-8")))
+            for path in sorted((current / "categories").glob("*/category.json"))
+        ]
+        public_items = [
+            validate_item(json.loads(path.read_text(encoding="utf-8")))
+            for path in sorted((current / "categories").glob("*/items/*/card.json"))
+        ]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise RegistrationError(
+            "active release public index is missing or malformed"
+        ) from exc
+    private_category_ids = {entry["category_id"] for entry in categories}
+    private_categories_by_id = {entry["category_id"]: entry for entry in categories}
+    public_categories_by_id = {entry["category_id"]: entry for entry in public_categories}
+    private_items_by_id = {
+        (entry["category_id"], entry["item_id"]): entry for entry in items
+    }
+    public_items_by_id = {
+        (entry["category_id"], entry["item_id"]): entry for entry in public_items
+    }
+    if (
+        public_index.get("category_count") != len(categories)
+        or public_index.get("item_count") != len(items)
+        or len(public_categories) != len(categories)
+        or len(public_items) != len(items)
+        or public_category_ids != private_category_ids
+        or private_categories_by_id != public_categories_by_id
+        or private_items_by_id != public_items_by_id
+    ):
+        raise RegistrationError(
+            "private registry state disagrees with the active public index"
+        )
+    return categories, items
+
+
+def _activate_release(archive: Path, release: Path) -> None:
+    relative_target = release.relative_to(archive)
+    temporary_link = archive / f".current-{uuid.uuid4().hex}.tmp"
+    current = archive / "current"
+    try:
+        os.symlink(relative_target, temporary_link)
+        os.replace(temporary_link, current)
+        try:
+            directory_fd = os.open(archive, os.O_RDONLY)
+        except OSError:
+            # The atomic swap has already committed. Directory durability is
+            # best-effort on filesystems that reject opening directories.
+            return
+        try:
+            try:
+                os.fsync(directory_fd)
+            except OSError:
+                # The public swap has already committed. Some filesystems do
+                # not support directory fsync; reporting failure now would be
+                # false because readers already see the complete new release.
+                pass
+        finally:
+            try:
+                os.close(directory_fd)
+            except OSError:
+                # Closing the directory descriptor happens after the atomic
+                # public swap; never turn a committed update into a false
+                # failure report.
+                pass
+    finally:
+        try:
+            if temporary_link.is_symlink():
+                temporary_link.unlink()
+        except OSError:
+            # Cleanup is best-effort and must not mask either the activation
+            # result or an earlier pre-swap failure.
+            pass
+
+
+def _commit_release(archive: Path, categories: list[dict], items: list[dict]) -> None:
+    releases = archive / ".releases"
+    releases.mkdir(parents=True, exist_ok=True)
+    staging = archive / f".staging-{uuid.uuid4().hex}"
+    release = releases / uuid.uuid4().hex
+    try:
+        staging.mkdir()
+        (staging / "_registry" / "categories").mkdir(parents=True)
+        (staging / "_registry" / "items").mkdir(parents=True)
+        for category in categories:
+            _atomic_json(
+                staging / "_registry" / "categories" / f"{category['category_id']}.json",
+                category,
+            )
+        for item in items:
+            _atomic_json(
+                staging
+                / "_registry"
+                / "items"
+                / item["category_id"]
+                / f"{item['item_id']}.json",
+                item,
+            )
+        write_public_site(staging, categories, items)
+        os.replace(staging, release)
+        _activate_release(archive, release)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+
+
+def _with_lock(root: Path, mutator) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".registry.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            categories, items = _load_current(root)
+            categories, items = mutator(categories, items)
+            _commit_release(root, categories, items)
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+def register_category(payload: object, root: Path = DEFAULT_ARCHIVE) -> Path:
+    category = validate_category(payload)
+    archive = Path(root).expanduser().resolve()
+
+    def mutate(categories: list[dict], items: list[dict]):
+        categories = [entry for entry in categories if entry["category_id"] != category["category_id"]]
+        categories.append(category)
+        return categories, items
+
+    _with_lock(archive, mutate)
+    return archive / "current" / "categories" / category["category_id"] / "category.json"
+
+
+def register_item(payload: object, root: Path = DEFAULT_ARCHIVE) -> Path:
+    item = validate_item(payload)
+    archive = Path(root).expanduser().resolve()
+
+    def mutate(categories: list[dict], items: list[dict]):
+        if item["category_id"] not in {entry["category_id"] for entry in categories}:
+            raise RegistrationError(
+                f"category must be registered first: {item['category_id']}"
+            )
+        items = [
+            entry
+            for entry in items
+            if not (
+                entry["category_id"] == item["category_id"]
+                and entry["item_id"] == item["item_id"]
+            )
+        ]
+        items.append(item)
+        return categories, items
+
+    _with_lock(archive, mutate)
+    return (
+        archive
+        / "current"
+        / "categories"
+        / item["category_id"]
+        / "items"
+        / item["item_id"]
+        / "card.json"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("category", "item"):
+        child = subparsers.add_parser(command)
+        child.add_argument("--card-json", required=True, type=Path)
+        child.add_argument("--root", type=Path, default=DEFAULT_ARCHIVE)
+    args = parser.parse_args()
+    payload = json.loads(args.card_json.read_text(encoding="utf-8"))
+    if args.command == "category":
+        destination = register_category(payload, args.root)
+    else:
+        destination = register_item(payload, args.root)
+    print(f"Registered {destination}")
+    print(f"Hub {args.root / 'current' / 'dashboard.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/content-hub/registry_schema.py
+++ b/projects/content-hub/registry_schema.py
@@ -1,0 +1,179 @@
+"""Validation contracts for the generic two-level content hub."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from datetime import datetime
+from urllib.parse import urlsplit
+
+
+class ValidationError(ValueError):
+    """Raised when public registry metadata violates its schema."""
+
+
+CATEGORY_REQUIRED = {
+    "schema_version",
+    "category_id",
+    "title",
+    "subtitle",
+    "description",
+    "icon",
+    "accent",
+    "sort_order",
+    "item_label",
+    "source_skill",
+}
+ITEM_REQUIRED = {
+    "schema_version",
+    "category_id",
+    "item_id",
+    "title",
+    "subtitle",
+    "published_at",
+    "primary_url",
+    "source_url",
+    "summary",
+    "badges",
+    "stats",
+    "highlights",
+    "tags",
+    "source_skill",
+}
+CATEGORY_ID = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+ITEM_ID = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$")
+ACCENTS = {"terracotta", "teal", "blue", "purple", "amber", "green"}
+
+
+def _validate_exact_fields(payload: object, required: set[str], kind: str) -> dict:
+    if not isinstance(payload, dict):
+        raise ValidationError(f"{kind} card must be a JSON object")
+    missing = required - set(payload)
+    unknown = set(payload) - required
+    if missing:
+        raise ValidationError(f"missing {kind} field(s): {', '.join(sorted(missing))}")
+    if unknown:
+        raise ValidationError(f"unknown {kind} field(s): {', '.join(sorted(unknown))}")
+    if type(payload["schema_version"]) is not int or payload["schema_version"] != 1:
+        raise ValidationError("schema_version must be the integer 1")
+    return dict(payload)
+
+
+def _text(name: str, value: object, *, maximum: int, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{name} must be a string")
+    if not allow_empty and not value.strip():
+        raise ValidationError(f"{name} must not be empty")
+    if len(value) > maximum:
+        raise ValidationError(f"{name} must be <= {maximum} characters")
+    if any(ord(char) < 32 and char not in "\t\n" for char in value):
+        raise ValidationError(f"{name} contains control characters")
+    return value
+
+
+def _https_url(name: str, value: object) -> str:
+    value = _text(name, value, maximum=2048)
+    if "\\" in value or any(ord(char) < 32 for char in value):
+        raise ValidationError(f"{name} contains unsafe characters")
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as exc:
+        raise ValidationError(f"{name} is not a valid URL") from exc
+    if parsed.scheme != "https" or not parsed.netloc or not hostname:
+        raise ValidationError(f"{name} must be an absolute https URL with a hostname")
+    if parsed.username or parsed.password:
+        raise ValidationError(f"{name} must not contain credentials")
+    if port is not None and not (1 <= port <= 65535):
+        raise ValidationError(f"{name} contains an invalid port")
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            ascii_hostname = hostname.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ValidationError(f"{name} contains an invalid hostname") from exc
+        labels = ascii_hostname.split(".")
+        if (
+            len(ascii_hostname) > 253
+            or any(
+                not label
+                or len(label) > 63
+                or not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?", label)
+                for label in labels
+            )
+        ):
+            raise ValidationError(f"{name} contains an invalid hostname")
+    return value
+
+
+def parse_published_at(value: object) -> datetime:
+    value = _text("published_at", value, maximum=64)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError("published_at must be valid ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise ValidationError("published_at must include a timezone offset")
+    return parsed
+
+
+def validate_category(payload: object) -> dict:
+    card = _validate_exact_fields(payload, CATEGORY_REQUIRED, "category")
+    if not isinstance(card["category_id"], str) or not CATEGORY_ID.fullmatch(card["category_id"]):
+        raise ValidationError("category_id must match [a-z0-9-]+ and be <=64 characters")
+    for name, maximum in (
+        ("title", 120),
+        ("subtitle", 160),
+        ("description", 500),
+        ("icon", 16),
+        ("item_label", 40),
+        ("source_skill", 120),
+    ):
+        _text(name, card[name], maximum=maximum)
+    if not isinstance(card["accent"], str) or card["accent"] not in ACCENTS:
+        raise ValidationError(f"accent must be one of {sorted(ACCENTS)}")
+    if type(card["sort_order"]) is not int or not (-1000 <= card["sort_order"] <= 1000):
+        raise ValidationError("sort_order must be an integer between -1000 and 1000")
+    return card
+
+
+def _validate_string_list(name: str, value: object, *, maximum_items: int, maximum_length: int) -> None:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise ValidationError(f"{name} must be an array with at most {maximum_items} items")
+    for item in value:
+        _text(f"{name} item", item, maximum=maximum_length)
+
+
+def validate_item(payload: object) -> dict:
+    card = _validate_exact_fields(payload, ITEM_REQUIRED, "item")
+    if not isinstance(card["category_id"], str) or not CATEGORY_ID.fullmatch(card["category_id"]):
+        raise ValidationError("category_id must match [a-z0-9-]+ and be <=64 characters")
+    if not isinstance(card["item_id"], str) or not ITEM_ID.fullmatch(card["item_id"]):
+        raise ValidationError("item_id must match [a-z0-9-]+ and be <=128 characters")
+    for name, maximum in (
+        ("title", 180),
+        ("subtitle", 300),
+        ("summary", 800),
+        ("source_skill", 120),
+    ):
+        _text(name, card[name], maximum=maximum)
+    parse_published_at(card["published_at"])
+    _https_url("primary_url", card["primary_url"])
+    _text("source_url", card["source_url"], maximum=2048, allow_empty=True)
+    if card["source_url"]:
+        _https_url("source_url", card["source_url"])
+    _validate_string_list("badges", card["badges"], maximum_items=3, maximum_length=40)
+    _validate_string_list("highlights", card["highlights"], maximum_items=5, maximum_length=200)
+    _validate_string_list("tags", card["tags"], maximum_items=8, maximum_length=40)
+    stats = card["stats"]
+    if not isinstance(stats, list) or len(stats) > 3:
+        raise ValidationError("stats must be an array with at most 3 items")
+    for stat in stats:
+        if not isinstance(stat, dict) or set(stat) != {"label", "value", "sub"}:
+            raise ValidationError("each stat must contain exactly label, value, and sub")
+        _text("stat label", stat["label"], maximum=40)
+        _text("stat value", stat["value"], maximum=80)
+        _text("stat sub", stat["sub"], maximum=120, allow_empty=True)
+    return card

--- a/projects/content-hub/tests/test_registry.py
+++ b/projects/content-hub/tests/test_registry.py
@@ -1,0 +1,440 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT))
+
+
+class ContentHubRegistryTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.category = {
+            "schema_version": 1,
+            "category_id": "skill-learning",
+            "title": "Skill Learning",
+            "subtitle": "双语技能学习",
+            "description": "保留原始 SKILL.md，并提供双语阅读、语境词汇和设计拆解。",
+            "icon": "📘",
+            "accent": "terracotta",
+            "sort_order": 20,
+            "item_label": "份学习报告",
+            "source_skill": "skill-learning-reports",
+        }
+        self.item = {
+            "schema_version": 1,
+            "category_id": "skill-learning",
+            "item_id": "ask-matt-3d38910535f01e15bc5fd7f6ca8880d628cd248741f08e6780dd7c1828e832",
+            "title": "ask-matt",
+            "subtitle": "skills/engineering/ask-matt/SKILL.md",
+            "published_at": "2026-08-10T08:22:49+08:00",
+            "primary_url": "https://share.ai.jingtao.fun/9876dac2-cb2e-4234-8658-9f5fc000ef32.html?v=7",
+            "source_url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/ask-matt/SKILL.md",
+            "summary": "把独立 skills 组织成按工作阶段导航、分流和汇流的流程地图。",
+            "badges": ["Promoted"],
+            "stats": [
+                {"label": "序号", "value": "#02", "sub": "学习系列"},
+                {"label": "版本", "value": "84fdeffd", "sub": "上游 commit"},
+            ],
+            "highlights": ["on-ramp", "leave a paper trail"],
+            "tags": ["workflow", "engineering"],
+            "source_skill": "skill-learning-reports",
+        }
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    @property
+    def public_root(self):
+        return self.root / "current"
+
+    def test_category_registration_builds_level_one_and_level_two_pages(self):
+        from register import register_category
+
+        destination = register_category(self.category, self.root)
+
+        self.assertEqual(
+            destination,
+            self.public_root / "categories" / "skill-learning" / "category.json",
+        )
+        self.assertTrue((self.public_root / "dashboard.html").is_file())
+        self.assertTrue((self.public_root / "index.json").is_file())
+        self.assertTrue((self.public_root / "categories" / "skill-learning" / "index.html").is_file())
+        self.assertTrue((self.public_root / "categories" / "skill-learning" / "index.json").is_file())
+        index = json.loads((self.public_root / "index.json").read_text())
+        self.assertEqual(index["category_count"], 1)
+        self.assertEqual(index["item_count"], 0)
+
+    def test_item_registration_requires_existing_category_and_updates_both_levels(self):
+        from register import RegistrationError, register_category, register_item
+
+        with self.assertRaises(RegistrationError):
+            register_item(self.item, self.root)
+
+        register_category(self.category, self.root)
+        destination = register_item(self.item, self.root)
+
+        self.assertEqual(
+            destination,
+            self.public_root
+            / "categories"
+            / "skill-learning"
+            / "items"
+            / self.item["item_id"]
+            / "card.json",
+        )
+        root_index = json.loads((self.public_root / "index.json").read_text())
+        category_index = json.loads(
+            (self.public_root / "categories" / "skill-learning" / "index.json").read_text()
+        )
+        self.assertEqual(root_index["item_count"], 1)
+        self.assertEqual(category_index["item_count"], 1)
+        self.assertEqual(category_index["items"][0]["item_id"], self.item["item_id"])
+
+    def test_item_may_omit_external_source_link_with_empty_string(self):
+        from register import register_category, register_item
+
+        register_category(self.category, self.root)
+        register_item(dict(self.item, source_url=""), self.root)
+        category_html = (
+            self.public_root / "categories" / "skill-learning" / "index.html"
+        ).read_text()
+        self.assertNotIn('class="source-link"', category_html)
+
+    def test_item_registration_is_idempotent_for_same_category_and_item_id(self):
+        from register import register_category, register_item
+
+        register_category(self.category, self.root)
+        register_item(self.item, self.root)
+        register_item(dict(self.item, summary="Updated summary"), self.root)
+
+        cards = list(self.public_root.glob("categories/*/items/*/card.json"))
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(json.loads(cards[0].read_text())["summary"], "Updated summary")
+
+    def test_registering_new_category_does_not_lose_existing_categories_or_items(self):
+        from register import register_category, register_item
+
+        register_category(self.category, self.root)
+        register_item(self.item, self.root)
+        finance = dict(
+            self.category,
+            category_id="investment-research",
+            title="Investment Research",
+            subtitle="投资研究",
+            icon="📈",
+            accent="teal",
+            sort_order=10,
+            item_label="份研究报告",
+            source_skill="investment-research-registry",
+        )
+        register_category(finance, self.root)
+
+        index = json.loads((self.public_root / "index.json").read_text())
+        self.assertEqual(index["category_count"], 2)
+        self.assertEqual(index["item_count"], 1)
+        self.assertEqual(
+            [entry["category_id"] for entry in index["categories"]],
+            ["investment-research", "skill-learning"],
+        )
+
+    def test_registry_rejects_unknown_missing_or_unsafe_category_fields(self):
+        from register import RegistrationError, register_category
+
+        invalid_cards = []
+        missing = dict(self.category)
+        missing.pop("description")
+        invalid_cards.append(missing)
+        invalid_cards.extend(
+            [
+                dict(self.category, schema_version=True),
+                dict(self.category, schema_version=1.0),
+                dict(self.category, category_id="../escape"),
+                dict(self.category, category_id="skill_learning"),
+                dict(self.category, category_id="bad-"),
+                dict(self.category, accent="rainbow"),
+                dict(self.category, accent=["teal"]),
+                dict(self.category, secret_note="do not publish"),
+            ]
+        )
+        for card in invalid_cards:
+            with self.subTest(card=card):
+                with self.assertRaises(RegistrationError):
+                    register_category(card, self.root)
+
+    def test_registry_rejects_unknown_missing_or_unsafe_item_fields(self):
+        from register import RegistrationError, register_category, register_item
+
+        register_category(self.category, self.root)
+        invalid_cards = []
+        missing = dict(self.item)
+        missing.pop("primary_url")
+        invalid_cards.append(missing)
+        invalid_cards.extend(
+            [
+                dict(self.item, schema_version=True),
+                dict(self.item, item_id="../escape"),
+                dict(self.item, item_id="bad-"),
+                dict(self.item, category_id="bad-"),
+                dict(self.item, primary_url="javascript:alert(1)"),
+                dict(self.item, primary_url="https://:443/path"),
+                dict(self.item, primary_url="https://exa mple.com/path"),
+                dict(self.item, primary_url="https://./path"),
+                dict(self.item, primary_url="https://-bad-.example/path"),
+                dict(self.item, badges=["x"] * 5),
+                dict(self.item, stats=[{"label": "x", "value": "y", "sub": "z"}] * 5),
+                dict(self.item, extra_private_note="no"),
+            ]
+        )
+        for card in invalid_cards:
+            with self.subTest(card=card):
+                with self.assertRaises(RegistrationError):
+                    register_item(card, self.root)
+
+    def test_dashboard_escapes_untrusted_text_and_preserves_safe_links(self):
+        from register import register_category, register_item
+
+        category = dict(self.category, title='<img src=x onerror="alert(1)">')
+        item = dict(self.item, summary="<script>alert(1)</script>")
+        register_category(category, self.root)
+        register_item(item, self.root)
+
+        root_html = (self.public_root / "dashboard.html").read_text()
+        category_html = (
+            self.public_root / "categories" / "skill-learning" / "index.html"
+        ).read_text()
+        self.assertNotIn("<img src=x", root_html)
+        self.assertNotIn("<script>alert(1)</script>", category_html)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", category_html)
+        self.assertIn(self.item["primary_url"].replace("&", "&amp;"), category_html)
+
+    def test_categories_sort_by_order_and_items_sort_by_actual_instant(self):
+        from build_site import build_site
+
+        finance = dict(
+            self.category,
+            category_id="investment-research",
+            title="Investment Research",
+            sort_order=10,
+        )
+        earlier = dict(self.item, published_at="2026-08-16T00:00:00+14:00", title="Earlier")
+        later = dict(
+            self.item,
+            item_id="later-item",
+            published_at="2026-08-15T23:00:00-12:00",
+            title="Later",
+        )
+        rendered = build_site([self.category, finance], [earlier, later])
+
+        self.assertLess(
+            rendered.root_html.index("Investment Research"),
+            rendered.root_html.index("Skill Learning"),
+        )
+        category_html = rendered.category_html["skill-learning"]
+        self.assertLess(category_html.index(">Later<"), category_html.index(">Earlier<"))
+
+    def test_builder_rejects_duplicate_item_identity(self):
+        from build_site import build_site
+
+        with self.assertRaises(ValueError):
+            build_site(
+                [self.category],
+                [self.item, dict(self.item, summary="different")],
+            )
+
+    def test_active_public_release_is_unchanged_when_activation_fails(self):
+        from unittest.mock import patch
+
+        import register
+
+        register.register_category(self.category, self.root)
+        before = (self.public_root / "index.json").read_text()
+        with patch("register._activate_release", side_effect=OSError("simulated interruption")):
+            with self.assertRaises(OSError):
+                register.register_item(self.item, self.root)
+
+        self.assertEqual((self.public_root / "index.json").read_text(), before)
+        self.assertFalse(any(self.public_root.glob("categories/*/items/*/card.json")))
+
+    def test_missing_current_after_prior_release_fails_closed(self):
+        from register import RegistrationError, register_category
+
+        register_category(self.category, self.root)
+        self.public_root.unlink()
+
+        with self.assertRaises(RegistrationError):
+            register_category(dict(self.category, category_id="other"), self.root)
+
+    def test_missing_private_registry_inside_current_fails_closed(self):
+        from register import RegistrationError, register_category
+
+        register_category(self.category, self.root)
+        registry_root = self.public_root / "_registry"
+        for path in sorted(registry_root.rglob("*"), reverse=True):
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+        registry_root.rmdir()
+
+        with self.assertRaises(RegistrationError):
+            register_category(dict(self.category, category_id="other"), self.root)
+
+    def test_emptied_private_registry_fails_closed_against_public_index(self):
+        from register import RegistrationError, register_category
+
+        register_category(self.category, self.root)
+        for path in (self.public_root / "_registry").glob("**/*.json"):
+            path.unlink()
+
+        with self.assertRaises(RegistrationError):
+            register_category(dict(self.category, category_id="other"), self.root)
+
+    def test_missing_single_private_item_fails_closed_against_public_index(self):
+        from register import RegistrationError, register_category, register_item
+
+        register_category(self.category, self.root)
+        register_item(self.item, self.root)
+        private_item = next((self.public_root / "_registry" / "items").glob("*/*.json"))
+        private_item.unlink()
+
+        with self.assertRaises(RegistrationError):
+            register_category(self.category, self.root)
+
+    def test_count_preserving_private_item_substitution_fails_closed(self):
+        from register import RegistrationError, register_category, register_item
+
+        register_category(self.category, self.root)
+        register_item(self.item, self.root)
+        register_item(dict(self.item, item_id="second"), self.root)
+        private_item = next(
+            (self.public_root / "_registry" / "items" / "skill-learning").glob("*.json")
+        )
+        substituted = json.loads(private_item.read_text())
+        substituted["item_id"] = "third"
+        private_item.unlink()
+        (private_item.parent / "third.json").write_text(json.dumps(substituted))
+
+        with self.assertRaises(RegistrationError):
+            register_category(self.category, self.root)
+
+    def test_post_swap_directory_fsync_failure_does_not_report_false_failure(self):
+        from unittest.mock import patch
+
+        import register
+
+        register.register_category(self.category, self.root)
+        original_fsync = register.os.fsync
+
+        def fail_directory_fsync(fd):
+            if register.os.path.isdir(f"/proc/self/fd/{fd}"):
+                raise OSError("simulated directory fsync failure")
+            return original_fsync(fd)
+
+        with patch("register.os.fsync", side_effect=fail_directory_fsync):
+            register.register_item(self.item, self.root)
+
+        self.assertEqual(
+            json.loads((self.public_root / "index.json").read_text())["item_count"], 1
+        )
+
+    def test_post_swap_directory_open_failure_does_not_report_false_failure(self):
+        from unittest.mock import patch
+
+        import register
+
+        register.register_category(self.category, self.root)
+        original_open = register.os.open
+
+        def fail_archive_directory_open(path, flags, *args, **kwargs):
+            if Path(path) == self.root:
+                raise OSError("simulated directory open failure")
+            return original_open(path, flags, *args, **kwargs)
+
+        with patch("register.os.open", side_effect=fail_archive_directory_open):
+            register.register_item(self.item, self.root)
+
+        self.assertEqual(
+            json.loads((self.public_root / "index.json").read_text())["item_count"], 1
+        )
+
+    def test_post_swap_directory_close_failure_does_not_report_false_failure(self):
+        from unittest.mock import patch
+
+        import register
+
+        register.register_category(self.category, self.root)
+        with patch("register.os.close", side_effect=OSError("simulated close failure")):
+            register.register_item(self.item, self.root)
+
+        self.assertEqual(
+            json.loads((self.public_root / "index.json").read_text())["item_count"], 1
+        )
+
+    def test_builder_refuses_to_mutate_active_public_release(self):
+        from unittest.mock import patch
+
+        import build_site
+
+        release = self.root / ".releases" / "base"
+        release.mkdir(parents=True)
+        (self.root / "current").symlink_to(Path(".releases/base"))
+        with patch("build_site.DEFAULT_ARCHIVE", self.root, create=True):
+            with self.assertRaises(RuntimeError):
+                build_site.write_public_site(release, [self.category], [])
+
+    def test_builder_detects_active_release_for_custom_archive_without_global_patch(self):
+        import build_site
+
+        release = self.root / ".releases" / "base"
+        release.mkdir(parents=True)
+        (self.root / "current").symlink_to(Path(".releases/base"))
+
+        with self.assertRaises(RuntimeError):
+            build_site.write_public_site(release, [self.category], [])
+
+    def test_builder_refuses_to_write_inside_active_release_descendant(self):
+        import build_site
+
+        release = self.root / ".releases" / "base"
+        release.mkdir(parents=True)
+        (self.root / "current").symlink_to(Path(".releases/base"))
+
+        with self.assertRaises(RuntimeError):
+            build_site.write_public_site(release / "nested", [self.category], [])
+
+    def test_cli_subcommands_register_category_and_item(self):
+        from register import main
+        from unittest.mock import patch
+
+        category_path = self.root / "category-input.json"
+        item_path = self.root / "item-input.json"
+        category_path.write_text(json.dumps(self.category))
+        item_path.write_text(json.dumps(self.item))
+
+        with redirect_stdout(io.StringIO()):
+            with patch.object(
+                sys,
+                "argv",
+                ["register.py", "category", "--card-json", str(category_path), "--root", str(self.root)],
+            ):
+                main()
+            with patch.object(
+                sys,
+                "argv",
+                ["register.py", "item", "--card-json", str(item_path), "--root", str(self.root)],
+            ):
+                main()
+
+        self.assertEqual(
+            json.loads((self.public_root / "index.json").read_text())["item_count"], 1
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a generic two-level category/item content registry at hub.ai.jingtao.fun
- publish immutable releases through an atomic current symlink with fail-closed state consistency checks
- add strict schemas, HTML escaping, Nginx public-route whitelist, and Docker deployment
- backfill is maintained in the runtime archive outside git; Skill Learning and investment research now share the registry contract

## Verification
- 23 unit/adversarial tests pass
- Python compile passes
- Docker Compose config passes
- Nginx config passes
- Gitleaks staged scan passes
- independent review probes cover incomplete/substituted state and post-swap failure semantics