### PR TITLE
refactor: unify Content Hub registration

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -33,7 +33,7 @@ projects/
 | [nav-portal](nav-portal/) | `nav.${S_DOMAIN}` | Navigation dashboard with Docker service auto-discovery |
 | [experience-manager](experience-manager/) | `ems.ai.jingtao.fun` | AI agent experience storage and semantic search (EMS) |
 | [ai-task-engine](ai-task-engine/) | `localhost:3200` | Workflow engine for AI task orchestration with Discord, EMS, and OpenClaw integration |
-| [finance](finance/) | `finance.${S_DOMAIN}` | Unified investment-research hub — dashboard + per-report browser for `~/finance/reports/` (理财/股票/保险/基金/...) |
+| [finance](finance/) | `finance.${S_DOMAIN}` | Legacy read-only investment-report archive retained for historical URL compatibility |
 | [content-hub](content-hub/) | `hub.${S_DOMAIN}` | Generic two-level content registry: category directory → searchable category dashboards → canonical artifact links |
 | [share-hosting](share-hosting/) | `share.${S_DOMAIN}` | UUID-only static file share for ad-hoc HTML/PDF/MD/TXT — unguessable paths, scan-resistant |
 

--- a/projects/content-hub/README.md
+++ b/projects/content-hub/README.md
@@ -16,14 +16,14 @@ Examples of categories:
 - `skill-learning` — bilingual Skill Learning reports
 - future categories can be added without changing the renderer or Nginx configuration
 
-## Registry API
+## Single registry CLI
 
-One CLI owns both registration levels:
+This is the only active registration mechanism for durable HTML artifacts. One CLI owns both registration levels:
 
 ```bash
-# Register or update a category
+# Ensure a category from the version-controlled catalog
 python3 ~/ai-learn/projects/content-hub/register.py category \
-  --card-json /path/to/category.json
+  --category-id investment-research
 
 # Register or update an item inside an existing category
 python3 ~/ai-learn/projects/content-hub/register.py item \
@@ -31,6 +31,18 @@ python3 ~/ai-learn/projects/content-hub/register.py item \
 ```
 
 Category registration is idempotent by `category_id`. Item registration is idempotent by `(category_id, item_id)`. An item cannot be registered before its category exists.
+
+The previous finance-specific registry is retired. Existing `finance.ai.jingtao.fun` report URLs remain online as read-only compatibility targets, but all new investment reports publish their canonical HTML first and register directly into `investment-research` through this CLI.
+
+## Catalog and Skill integration audit
+
+- `catalog/categories/*.json` is the version-controlled source of truth for category presentation.
+- `catalog/integrations.json` records which Hermes Skills register durable artifacts, their category, and whether identities are stable, versioned, or collection-level.
+- `scripts/audit_integrations.py` checks the installed profile's Skills and rejects any remaining reference to the retired finance registry.
+
+```bash
+python3 scripts/audit_integrations.py
+```
 
 ## Atomic publication model
 
@@ -77,6 +89,7 @@ Private `_registry/`, `.releases/`, lock files, scripts, temporary files, and un
 ```bash
 cd ~/ai-learn/projects/content-hub
 python3 -m unittest -v tests/test_registry.py
+python3 -m unittest -v tests/test_audit_integrations.py
 python3 -m py_compile register.py build_site.py registry_schema.py
 docker run --rm \
   -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \

--- a/projects/content-hub/catalog/categories/english-learning.json
+++ b/projects/content-hub/catalog/categories/english-learning.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "english-learning",
+  "title": "English Learning",
+  "subtitle": "英语学习站点",
+  "description": "具有独立内部导航的长期英语学习项目与内容站点入口。",
+  "icon": "🎧",
+  "accent": "green",
+  "sort_order": 60,
+  "item_label": "个学习项目",
+  "source_skill": "aee-episode-pipeline"
+}

--- a/projects/content-hub/catalog/categories/financial-education.json
+++ b/projects/content-hub/catalog/categories/financial-education.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "financial-education",
+  "title": "Financial Education",
+  "subtitle": "金融知识学习",
+  "description": "面向非专业读者的金融指标、估值、现金流与股东回报教育网页。",
+  "icon": "🎓",
+  "accent": "blue",
+  "sort_order": 30,
+  "item_label": "份教育网页",
+  "source_skill": "financial-education-webpage"
+}

--- a/projects/content-hub/catalog/categories/gaokao-reports.json
+++ b/projects/content-hub/catalog/categories/gaokao-reports.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "gaokao-reports",
+  "title": "Gaokao Reports",
+  "subtitle": "高考志愿与专业研究",
+  "description": "志愿方案、既有草稿诊断、院校专业组评估与录取后专业解读。",
+  "icon": "🎯",
+  "accent": "purple",
+  "sort_order": 40,
+  "item_label": "份高考报告",
+  "source_skill": "jiangsu-gaokao"
+}

--- a/projects/content-hub/catalog/categories/investment-research.json
+++ b/projects/content-hub/catalog/categories/investment-research.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "investment-research",
+  "title": "Investment Research",
+  "subtitle": "投资研究",
+  "description": "股票、银行理财、基金、保险与跨资产比较的结构化研究归档。每个条目直接进入完整报告。",
+  "icon": "📈",
+  "accent": "teal",
+  "sort_order": 10,
+  "item_label": "份研究报告",
+  "source_skill": "content-hub-registry"
+}

--- a/projects/content-hub/catalog/categories/product-research.json
+++ b/projects/content-hub/catalog/categories/product-research.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "product-research",
+  "title": "Product Research",
+  "subtitle": "产品规格与购买研究",
+  "description": "基于官方说明书、产品页与可靠证据形成的产品规格、安装和横向对比报告。",
+  "icon": "🔎",
+  "accent": "amber",
+  "sort_order": 50,
+  "item_label": "份产品报告",
+  "source_skill": "content-hub-registry"
+}

--- a/projects/content-hub/catalog/categories/skill-learning.json
+++ b/projects/content-hub/catalog/categories/skill-learning.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "category_id": "skill-learning",
+  "title": "Skill Learning",
+  "subtitle": "双语技能学习",
+  "description": "保留原始 SKILL.md，提供段落对齐中文阅读、语境词汇弹窗与工程设计拆解。",
+  "icon": "📘",
+  "accent": "terracotta",
+  "sort_order": 20,
+  "item_label": "份学习报告",
+  "source_skill": "skill-learning-reports"
+}

--- a/projects/content-hub/catalog/integrations.json
+++ b/projects/content-hub/catalog/integrations.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "skills": {
+    "aee-episode-pipeline": {
+      "mode": "collection",
+      "category_id": "english-learning",
+      "identity_policy": "collection"
+    },
+    "cn-bank-wealth-products": {
+      "mode": "direct",
+      "category_id": "investment-research",
+      "identity_policy": "stable"
+    },
+    "cn-stock-financial-analysis": {
+      "mode": "direct",
+      "category_id": "investment-research",
+      "identity_policy": "stable"
+    },
+    "financial-education-webpage": {
+      "mode": "direct",
+      "category_id": "financial-education",
+      "identity_policy": "stable"
+    },
+    "haier-product-spec-docs": {
+      "mode": "direct",
+      "category_id": "product-research",
+      "identity_policy": "stable"
+    },
+    "insurance-brochure-analysis": {
+      "mode": "direct",
+      "category_id": "investment-research",
+      "identity_policy": "stable"
+    },
+    "jiangsu-gaokao": {
+      "mode": "direct",
+      "category_id": "gaokao-reports",
+      "identity_policy": "stable"
+    },
+    "scheduled-content-learning": {
+      "mode": "none",
+      "reason": "Framework skill; the owning producer chooses the category."
+    },
+    "share-hosting": {
+      "mode": "none",
+      "reason": "Publisher only; the owning producer decides whether an artifact is durable."
+    },
+    "skill-learning-reports": {
+      "mode": "direct",
+      "category_id": "skill-learning",
+      "identity_policy": "versioned"
+    }
+  }
+}

--- a/projects/content-hub/register.py
+++ b/projects/content-hub/register.py
@@ -13,9 +13,10 @@ import uuid
 from pathlib import Path
 
 from build_site import write_public_site
-from registry_schema import ValidationError, validate_category, validate_item
+from registry_schema import CATEGORY_ID, ValidationError, validate_category, validate_item
 
 DEFAULT_ARCHIVE = Path.home() / "content-hub"
+DEFAULT_CATEGORY_CATALOG = Path(__file__).resolve().parent / "catalog" / "categories"
 RegistrationError = ValidationError
 
 
@@ -227,18 +228,46 @@ def register_item(payload: object, root: Path = DEFAULT_ARCHIVE) -> Path:
     )
 
 
+def load_catalog_category(
+    category_id: str, catalog_root: Path = DEFAULT_CATEGORY_CATALOG
+) -> dict:
+    if not CATEGORY_ID.fullmatch(category_id):
+        raise RegistrationError("invalid category_id")
+    path = Path(catalog_root).expanduser().resolve() / f"{category_id}.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RegistrationError(f"cannot load category catalog entry: {category_id}") from exc
+    category = validate_category(payload)
+    if category["category_id"] != category_id:
+        raise RegistrationError("catalog filename and category_id disagree")
+    return category
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("category", "item"):
-        child = subparsers.add_parser(command)
-        child.add_argument("--card-json", required=True, type=Path)
-        child.add_argument("--root", type=Path, default=DEFAULT_ARCHIVE)
+    category_parser = subparsers.add_parser("category")
+    category_source = category_parser.add_mutually_exclusive_group(required=True)
+    category_source.add_argument("--card-json", type=Path)
+    category_source.add_argument("--category-id")
+    category_parser.add_argument(
+        "--catalog-root", type=Path, default=DEFAULT_CATEGORY_CATALOG
+    )
+    category_parser.add_argument("--root", type=Path, default=DEFAULT_ARCHIVE)
+
+    item_parser = subparsers.add_parser("item")
+    item_parser.add_argument("--card-json", required=True, type=Path)
+    item_parser.add_argument("--root", type=Path, default=DEFAULT_ARCHIVE)
     args = parser.parse_args()
-    payload = json.loads(args.card_json.read_text(encoding="utf-8"))
     if args.command == "category":
+        if args.card_json:
+            payload = json.loads(args.card_json.read_text(encoding="utf-8"))
+        else:
+            payload = load_catalog_category(args.category_id, args.catalog_root)
         destination = register_category(payload, args.root)
     else:
+        payload = json.loads(args.card_json.read_text(encoding="utf-8"))
         destination = register_item(payload, args.root)
     print(f"Registered {destination}")
     print(f"Hub {args.root / 'current' / 'dashboard.html'}")

--- a/projects/content-hub/scripts/audit_integrations.py
+++ b/projects/content-hub/scripts/audit_integrations.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Audit declared Hermes Skill integrations with the unified Content Hub."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from registry_schema import ValidationError, validate_category  # noqa: E402
+
+VALID_MODES = {"direct", "collection", "none"}
+DIRECT_IDENTITIES = {"stable", "versioned"}
+LEGACY_MARKERS = (
+    "investment-research-registry",
+    "register_report.py",
+    "finance.ai.jingtao.fun",
+    "finance hub",
+    "finance-hub",
+)
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _skill_paths(skills_root: Path, name: str) -> list[Path]:
+    return sorted(
+        path
+        for path in Path(skills_root).glob("*/*/SKILL.md")
+        if path.parent.name == name
+    )
+
+
+def _catalog_categories(category_catalog_root: Path) -> tuple[set[str], list[str]]:
+    category_ids: set[str] = set()
+    errors: list[str] = []
+    root = Path(category_catalog_root)
+    for path in sorted(root.glob("*.json")):
+        if path.is_symlink():
+            errors.append(f"category catalog may not contain symlinks: {path.name}")
+            continue
+        try:
+            category = validate_category(_load_json(path))
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            errors.append(f"invalid category catalog entry {path.name}: {exc}")
+            continue
+        category_id = category["category_id"]
+        if path.stem != category_id:
+            errors.append(
+                f"category catalog filename disagrees with category_id: {path.name}"
+            )
+        if category_id in category_ids:
+            errors.append(f"duplicate category_id in catalog: {category_id}")
+        category_ids.add(category_id)
+    if not category_ids:
+        errors.append("category catalog contains no valid categories")
+    return category_ids, errors
+
+
+def _expected_contract(policy: dict) -> str:
+    mode = policy["mode"]
+    if mode == "none":
+        return "**Content Hub contract:** none"
+    return (
+        f"**Content Hub contract:** {mode} · "
+        f"category={policy['category_id']} · identity={policy['identity_policy']}"
+    )
+
+
+def audit_integrations(
+    config_path: Path, skills_root: Path, category_catalog_root: Path
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        config = _load_json(config_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"integration catalog cannot be loaded: {exc}"]
+    if not isinstance(config, dict):
+        return ["integration catalog must be an object"]
+    if set(config) != {"schema_version", "skills"}:
+        errors.append("integration catalog has unknown or missing top-level fields")
+    if type(config.get("schema_version")) is not int or config.get("schema_version") != 1:
+        errors.append("integration catalog schema_version must be integer 1")
+    integrations = config.get("skills")
+    if not isinstance(integrations, dict):
+        errors.append("integration catalog skills must be an object")
+        return errors
+
+    contract_marked_skills: set[str] = set()
+    for installed_skill in Path(skills_root).glob("*/*/SKILL.md"):
+        try:
+            installed_text = installed_skill.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "**Content Hub contract:**" in installed_text:
+            contract_marked_skills.add(installed_skill.parent.name)
+    omitted_skills = contract_marked_skills - set(integrations)
+    for omitted_skill in sorted(omitted_skills):
+        errors.append(
+            f"{omitted_skill}: contract-marked Skill omitted from integration catalog"
+        )
+
+    known_categories, category_errors = _catalog_categories(category_catalog_root)
+    errors.extend(category_errors)
+
+    for name, policy in sorted(integrations.items()):
+        paths = _skill_paths(skills_root, name)
+        if len(paths) != 1:
+            errors.append(
+                f"{name}: expected exactly one installed SKILL.md, found {len(paths)}"
+            )
+            continue
+        skill_path = paths[0]
+        text = skill_path.read_text(encoding="utf-8")
+        description_match = re.search(r"^description:\s*[\"']?([^\n\"']+)", text, re.M)
+        if not description_match or len(description_match.group(1).strip()) > 60:
+            errors.append(f"{name}: description must be present and at most 60 characters")
+        if not isinstance(policy, dict):
+            errors.append(f"{name}: integration policy must be an object")
+            continue
+        mode = policy.get("mode")
+        if mode not in VALID_MODES:
+            errors.append(f"{name}: unsupported integration mode {mode!r}")
+            continue
+
+        expected_fields = (
+            {"mode", "reason"}
+            if mode == "none"
+            else {"mode", "category_id", "identity_policy"}
+        )
+        if set(policy) != expected_fields:
+            errors.append(
+                f"{name}: {mode} policy fields must be exactly {sorted(expected_fields)}"
+            )
+
+        for candidate in skill_path.parent.rglob("*"):
+            if not candidate.is_file():
+                continue
+            try:
+                candidate_bytes = candidate.read_bytes()
+            except OSError as exc:
+                errors.append(f"{name}: cannot read support file {candidate.name}: {exc}")
+                continue
+            if b"\x00" in candidate_bytes:
+                continue
+            try:
+                candidate_text = candidate_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                relative = candidate.relative_to(skill_path.parent)
+                errors.append(
+                    f"{name}: nonbinary support file is not valid UTF-8: {relative}"
+                )
+                continue
+            candidate_text_lower = candidate_text.lower()
+            for marker in LEGACY_MARKERS:
+                if marker in candidate_text_lower:
+                    relative = candidate.relative_to(skill_path.parent)
+                    errors.append(
+                        f"{name}: legacy registry marker remains in {relative}: {marker}"
+                    )
+
+        expected_contract = _expected_contract(policy)
+        contract_lines = re.findall(r"^\*\*Content Hub contract:\*\* .+$", text, re.M)
+        if contract_lines != [expected_contract]:
+            errors.append(
+                f"{name}: expected exactly one contract marker: {expected_contract}"
+            )
+
+        semantic_text = re.sub(r"[`*_]", "", text).lower()
+        semantic_sentences = [
+            sentence.strip()
+            for sentence in re.split(r"[.;。；\n]+", semantic_text)
+            if sentence.strip()
+        ]
+
+        if mode == "none":
+            if not isinstance(policy.get("reason"), str) or not policy["reason"].strip():
+                errors.append(f"{name}: none policy requires a non-empty reason")
+            if "does not register" not in semantic_text:
+                errors.append(
+                    f"{name}: none policy must state that this Skill does not register"
+                )
+            if re.search(
+                r"(?:register (?:reports?|artifacts?|items?) directly|register directly|"
+                r"must register|this skill registers)",
+                semantic_text,
+            ):
+                errors.append(
+                    f"{name}: none policy contains a conflicting direct registration instruction"
+                )
+            if "load content-hub-registry" in semantic_text:
+                errors.append(
+                    f"{name}: none policy may not load content-hub-registry directly"
+                )
+            positive_registration_sentence = any(
+                re.search(r"\bregister\b", sentence)
+                and not re.search(r"\b(do not|does not|don't|never|not)\b", sentence)
+                for sentence in semantic_sentences
+            )
+            if positive_registration_sentence:
+                errors.append(
+                    f"{name}: none policy contains a conflicting direct registration instruction"
+                )
+            continue
+
+        category_id = policy.get("category_id")
+        if category_id not in known_categories:
+            errors.append(f"{name}: unknown category_id {category_id!r}")
+        identity = policy.get("identity_policy")
+        if mode == "direct" and identity not in DIRECT_IDENTITIES:
+            errors.append(f"{name}: direct identity_policy must be stable or versioned")
+        direct_collection_workflow = any(
+            "collection" in sentence
+            and any(
+                action in sentence
+                for action in ("register", "maintain", "publish", "update")
+            )
+            for sentence in semantic_sentences
+        )
+        if mode == "direct" and direct_collection_workflow:
+            errors.append(f"{name}: direct policy contains a collection workflow")
+        if mode == "collection" and identity != "collection":
+            errors.append(f"{name}: collection identity_policy must be collection")
+        if mode == "collection" and "do not register every" not in semantic_text:
+            errors.append(
+                f"{name}: collection policy must say do not register every item"
+            )
+        positive_per_item_registration = any(
+            "register" in sentence
+            and re.search(r"\b(each|every|per[ -]?item)\b", sentence)
+            and not re.search(r"\b(do not|don't|never|not)\b", sentence)
+            for sentence in semantic_sentences
+        )
+        if mode == "collection" and positive_per_item_registration:
+            errors.append(
+                f"{name}: collection policy contains a positive per-item registration instruction"
+            )
+        if "load `content-hub-registry`" not in text.lower():
+            errors.append(
+                f"{name}: {mode} integration must explicitly load content-hub-registry"
+            )
+    return errors
+
+
+def main() -> int:
+    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=PROJECT_ROOT / "catalog" / "integrations.json",
+    )
+    parser.add_argument("--skills-root", type=Path, default=hermes_home / "skills")
+    parser.add_argument(
+        "--category-catalog-root",
+        type=Path,
+        default=PROJECT_ROOT / "catalog" / "categories",
+    )
+    args = parser.parse_args()
+    errors = audit_integrations(
+        args.config, args.skills_root, args.category_catalog_root
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Content Hub Skill integrations: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/content-hub/tests/test_audit_integrations.py
+++ b/projects/content-hub/tests/test_audit_integrations.py
@@ -1,0 +1,468 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT / "scripts"))
+
+
+class IntegrationAuditTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.skills_root = self.root / "skills"
+        self.catalog_root = self.root / "categories"
+        self.skills_root.mkdir()
+        self.catalog_root.mkdir()
+        category = {
+            "schema_version": 1,
+            "category_id": "investment-research",
+            "title": "Investment Research",
+            "subtitle": "投资研究",
+            "description": "Research reports.",
+            "icon": "📈",
+            "accent": "teal",
+            "sort_order": 10,
+            "item_label": "份研究报告",
+            "source_skill": "content-hub-registry",
+        }
+        (self.catalog_root / "investment-research.json").write_text(
+            json.dumps(category), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def write_skill(self, name: str, body: str) -> None:
+        path = self.skills_root / "research" / name / "SKILL.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            f"---\nname: {name}\ndescription: Test skill.\n---\n\n{body}\n",
+            encoding="utf-8",
+        )
+
+    def write_config(self, skills: dict) -> Path:
+        path = self.root / "integrations.json"
+        path.write_text(
+            json.dumps({"schema_version": 1, "skills": skills}),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_direct_integration_requires_new_registry_and_known_category(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "After publishing, load `content-hub-registry` and register the report.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        self.assertEqual(
+            audit_integrations(config, self.skills_root, self.catalog_root), []
+        )
+
+    def test_audit_rejects_contract_marked_skill_omitted_from_catalog(self):
+        from audit_integrations import audit_integrations
+
+        body = (
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry` and register the report."
+        )
+        self.write_skill("stock-report", body)
+        self.write_skill("wealth-report", body)
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("wealth-report" in error and "omitted" in error for error in errors))
+
+    def test_audit_rejects_any_legacy_finance_registry_reference(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "Call investment-research-registry and register_report.py.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("legacy" in error.lower() for error in errors))
+        self.assertTrue(any("content-hub-registry" in error for error in errors))
+
+    def test_audit_scans_skill_reference_files_for_legacy_registry(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "After publishing, load `content-hub-registry` and register the report.",
+        )
+        reference = (
+            self.skills_root
+            / "research"
+            / "stock-report"
+            / "references"
+            / "legacy.txt"
+        )
+        reference.parent.mkdir()
+        reference.write_text("Run register_report.py", encoding="utf-8")
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("references/legacy.txt" in error for error in errors))
+
+    def test_audit_fails_closed_on_nonbinary_invalid_utf8_support_file(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry` and register the report.",
+        )
+        support = (
+            self.skills_root
+            / "research"
+            / "stock-report"
+            / "references"
+            / "legacy.blob"
+        )
+        support.parent.mkdir()
+        support.write_bytes(b"register_report.py\xff")
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("valid UTF-8" in error for error in errors))
+
+    def test_audit_rejects_legacy_finance_hub_wording(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry`. Also register to finance hub.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("finance hub" in error for error in errors))
+
+    def test_audit_rejects_descriptions_over_sixty_characters(self):
+        from audit_integrations import audit_integrations
+
+        path = self.skills_root / "research" / "stock-report" / "SKILL.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "---\nname: stock-report\ndescription: "
+            + ("x" * 61)
+            + "\n---\n\nLoad content-hub-registry.\n",
+            encoding="utf-8",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("description" in error for error in errors))
+
+    def test_audit_rejects_policy_marker_or_identity_mismatch(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry` and register the report.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "collection",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("collection" in error for error in errors))
+        self.assertTrue(any("contract" in error for error in errors))
+
+    def test_audit_rejects_unknown_policy_fields_and_boolean_schema(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry` and register the report.",
+        )
+        config = self.root / "integrations.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "schema_version": True,
+                    "skills": {
+                        "stock-report": {
+                            "mode": "direct",
+                            "category_id": "investment-research",
+                            "identity_policy": "stable",
+                            "unexpected": "value",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("schema_version" in error for error in errors))
+        self.assertTrue(any("fields" in error for error in errors))
+
+    def test_audit_rejects_direct_contract_without_load_instruction(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("explicitly load" in error for error in errors))
+
+    def test_audit_rejects_direct_policy_with_collection_workflow(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry`. Do not register every report; maintain one collection entry.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("collection workflow" in error for error in errors))
+
+    def test_audit_rejects_conflicting_contract_markers(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n"
+            "**Content Hub contract:** collection · category=investment-research · identity=collection\n\n"
+            "Load `content-hub-registry` and register the report.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("exactly one contract" in error for error in errors))
+
+    def test_audit_rejects_collection_without_no_per_item_rule(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** collection · category=investment-research · identity=collection\n\n"
+            "Load `content-hub-registry` and register each report.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "collection",
+                    "category_id": "investment-research",
+                    "identity_policy": "collection",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("every item" in error for error in errors))
+
+    def test_audit_rejects_none_without_non_owner_statement(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** none\n\n"
+            "Load `content-hub-registry` and register reports directly.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "none",
+                    "reason": "Publisher only.",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("does not register" in error for error in errors))
+
+    def test_audit_rejects_none_with_conflicting_direct_instruction(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** none\n\n"
+            "This Skill does not register previews. "
+            "Register every finished report directly after publication.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "none",
+                    "reason": "Publisher only.",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("direct registration" in error for error in errors))
+
+    def test_audit_rejects_collection_with_positive_per_item_instruction(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** collection · category=investment-research · identity=collection\n\n"
+            "Load `content-hub-registry`. Do not register every item; register every report too.",
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "collection",
+                    "category_id": "investment-research",
+                    "identity_policy": "collection",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("per-item" in error for error in errors))
+
+    def test_audit_rejects_malformed_category_catalog_entry(self):
+        from audit_integrations import audit_integrations
+
+        self.write_skill(
+            "stock-report",
+            "**Content Hub contract:** direct · category=investment-research · identity=stable\n\n"
+            "Load `content-hub-registry` and register the report.",
+        )
+        malformed = json.loads(
+            (self.catalog_root / "investment-research.json").read_text()
+        )
+        malformed["schema_version"] = True
+        (self.catalog_root / "investment-research.json").write_text(
+            json.dumps(malformed), encoding="utf-8"
+        )
+        config = self.write_config(
+            {
+                "stock-report": {
+                    "mode": "direct",
+                    "category_id": "investment-research",
+                    "identity_policy": "stable",
+                }
+            }
+        )
+
+        errors = audit_integrations(config, self.skills_root, self.catalog_root)
+
+        self.assertTrue(any("category" in error.lower() for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/content-hub/tests/test_registry.py
+++ b/projects/content-hub/tests/test_registry.py
@@ -131,7 +131,7 @@ class ContentHubRegistryTests(unittest.TestCase):
             accent="teal",
             sort_order=10,
             item_label="份研究报告",
-            source_skill="investment-research-registry",
+            source_skill="content-hub-registry",
         )
         register_category(finance, self.root)
 
@@ -434,6 +434,48 @@ class ContentHubRegistryTests(unittest.TestCase):
         self.assertEqual(
             json.loads((self.public_root / "index.json").read_text())["item_count"], 1
         )
+
+    def test_cli_registers_category_from_central_catalog(self):
+        from register import main
+        from unittest.mock import patch
+
+        catalog_root = self.root / "catalog"
+        catalog_root.mkdir()
+        (catalog_root / "skill-learning.json").write_text(
+            json.dumps(self.category), encoding="utf-8"
+        )
+
+        with redirect_stdout(io.StringIO()):
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "register.py",
+                    "category",
+                    "--category-id",
+                    "skill-learning",
+                    "--catalog-root",
+                    str(catalog_root),
+                    "--root",
+                    str(self.root),
+                ],
+            ):
+                main()
+
+        category = json.loads(
+            (self.public_root / "categories" / "skill-learning" / "category.json").read_text()
+        )
+        self.assertEqual(category, self.category)
+
+    def test_all_shipped_catalog_categories_validate(self):
+        from register import DEFAULT_CATEGORY_CATALOG, load_catalog_category
+
+        paths = sorted(DEFAULT_CATEGORY_CATALOG.glob("*.json"))
+        self.assertGreaterEqual(len(paths), 6)
+        for path in paths:
+            with self.subTest(category_id=path.stem):
+                category = load_catalog_category(path.stem)
+                self.assertEqual(category["category_id"], path.stem)
 
 
 if __name__ == "__main__":

--- a/projects/content-hub/tests/test_retired_finance_registry.py
+++ b/projects/content-hub/tests/test_retired_finance_registry.py
@@ -1,0 +1,31 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+PROJECTS = Path(__file__).resolve().parents[2]
+TOMBSTONE = PROJECTS / "finance" / "retired_register_report.py"
+
+
+class RetiredFinanceRegistryTests(unittest.TestCase):
+    def test_tombstone_exits_two_without_writing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            before = sorted(path.relative_to(root) for path in root.rglob("*"))
+
+            result = subprocess.run(
+                ["python3", str(TOMBSTONE)],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            after = sorted(path.relative_to(root) for path in root.rglob("*"))
+            self.assertEqual(result.returncode, 2)
+            self.assertEqual(before, after)
+            self.assertIn("content-hub", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/finance/README.md
+++ b/projects/finance/README.md
@@ -1,6 +1,6 @@
-# finance — Investment Research Hub
+# finance — Legacy Investment Report Archive
 
-Dedicated subdomain for Jingtao's investment-research archive across all asset classes (理财 / 股票 / 保险 / 基金 / 债券 / 加密 / ...).
+Read-only compatibility service for historical investment-report URLs. New reports are no longer registered here; the single active navigation registry is `projects/content-hub`.
 
 **URL**: https://finance.ai.jingtao.fun
 
@@ -27,13 +27,13 @@ Hidden from web (server-side raw data only):
 
 ## Data source
 
-Read-only mount of `/home/jingtao/finance/reports/`. The dashboard regenerates on every `register_report.py` call (which any analysis skill invokes after publishing). nginx serves the freshly-written file with no restart needed.
+Read-only mount of `/home/jingtao/finance/reports/`. The existing dashboard and report paths stay online so bookmarks and Content Hub cards do not break. No Skill may call the retired `register_report.py` write path.
 
 ## Architecture
 
-- **Concurrency-safe**: each report lives in its own dir, dashboard build is pure scan. Multiple skills can register simultaneously.
-- **URL stable**: nginx whitelist regex on path means the URL contract is enforced — re-running an analysis with the same `(asset_class, owner, code)` reuses the URL.
-- **Overwrite semantics**: re-analysis replaces in place (typically what you want — show latest verdict). `--keep-history` flag preserves old version under `.history/`.
+- **Read-only compatibility**: historical report and dashboard URLs remain stable.
+- **No new writes**: all new financial HTML publishes to its canonical host and registers directly in the `investment-research` Content Hub category.
+- **Retirement boundary**: this service may be removed only after every historical card has migrated away from `finance.ai.jingtao.fun`.
 
 ## Naming history
 
@@ -46,10 +46,17 @@ cd ~/ai-learn/projects/finance
 docker compose down && docker compose up -d
 ```
 
+Install the fail-fast tombstone at the former write entry point:
+
+```bash
+install -m 755 retired_register_report.py \
+  /home/jingtao/finance/reports/register_report.py
+```
+
 First request after fresh deploy may take 5-30s while letsencrypt-companion issues the cert.
 
 ## Related
 
 - **share-hosting** (`share.ai.jingtao.fun`): UUID-only file share for ad-hoc reports — complements this with unstructured paths
-- **investment-research-registry** Hermes skill: the registration contract that all analysis skills follow
-- **cn-bank-wealth-products / cn-stock-financial-analysis / insurance-brochure-analysis** Hermes skills: analysis skills that populate this dashboard
+- **content-hub-registry** Hermes Skill: the only active registration contract
+- **cn-bank-wealth-products / cn-stock-financial-analysis / insurance-brochure-analysis** Hermes Skills: publish canonical HTML and register directly in Content Hub

--- a/projects/finance/retired_register_report.py
+++ b/projects/finance/retired_register_report.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Fail-fast tombstone for the retired finance-specific registry."""
+
+import sys
+
+MESSAGE = """The finance-specific registry has been retired.
+Publish the canonical HTML, then use:
+  python3 /home/jingtao/ai-learn/projects/content-hub/register.py category --category-id investment-research
+  python3 /home/jingtao/ai-learn/projects/content-hub/register.py item --card-json <item.json>
+Existing finance report URLs remain read-only for compatibility.
+"""
+
+if __name__ == "__main__":
+    print(MESSAGE, file=sys.stderr)
+    raise SystemExit(2)


### PR DESCRIPTION
## Summary
- make Content Hub the only active registry for durable HTML artifacts
- add version-controlled category and Skill-integration catalogs
- add fail-closed audits for legacy Finance registration, policy drift, omitted producers, malformed catalogs, and support-file bypasses
- retire the Finance write entry point with a no-write tombstone while preserving historical report URLs read-only

## Runtime migration
- migrated financial, Skill Learning, education, Gaokao, product, AEE, publisher, and scheduler Skills to explicit Content Hub contracts
- removed the `investment-research-registry` Skill after absorbing its mapping into `content-hub-registry`
- registered the AEE collection and refreshed live Content Hub categories

## Verification
- `python3 -m unittest discover -s projects/content-hub/tests -p "test_*.py" -q` — 43 passed
- `python3 projects/content-hub/scripts/audit_integrations.py` — OK
- staged Gitleaks — no leaks
- independent targeted review — passed
- all 20 historical Finance reports and cards remain HTTP 200