### PR TITLE
Increase quant MLflow memory headroom

### DIFF
--- a/projects/quant-research-platform/compose.yaml
+++ b/projects/quant-research-platform/compose.yaml
@@ -12,7 +12,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
-    mem_limit: 1600m
+    mem_limit: 2200m
     cpus: 0.50
     restart: unless-stopped
 


### PR DESCRIPTION
Real artifact logging raised MLflow memory to 1.55 GiB against a 1.56 GiB limit. Increase the cgroup limit to 2.2 GiB; one worker remains enforced and the three-service configured limits still fit the 8 GiB research node.

Verified on feng-learn after recreation: MLflow health 200 and current usage 637 MiB / 2.148 GiB.