### PR TITLE
Add second-round gold strategy robustness study

### DIFF
--- a/projects/quant-research-platform/README.md
+++ b/projects/quant-research-platform/README.md
@@ -18,6 +18,26 @@ A reproducible, research-only vertical slice for daily gold strategy analysis. I
 6. Produces decision-first, 390 px-friendly HTML with comparisons, equity/trade charts, ledger, caveats, and run metadata.
 7. Uses a Prefect flow and logs one MLflow run per symbol/strategy, including full, OOS, and cost-stress prefixed metrics plus complete research artifacts.
 
+## Round-two robustness study
+
+`gold_research.round2.run_round2_research` adds four frozen, long-only candidates without selecting a winner after seeing the results:
+
+- close above the 200-session moving average;
+- positive 252-session absolute momentum;
+- a two-of-three vote across 63/126/252-session momentum;
+- the 200-session trend filter scaled to a 10% volatility target.
+
+The study aligns every strategy after a shared 315-session warm-up, evaluates 5/10/20 bps one-way costs, reports calendar-year pseudo-out-of-sample folds from 2010, checks small parameter neighborhoods, and compares each timing rule with buy-and-hold using a paired 20-session moving-block bootstrap. Its familywise confidence level is Bonferroni-adjusted across the 12 strategy/instrument comparisons. Because the complete historical period has already been inspected, these folds are retrospective stress tests, not a pristine final holdout.
+
+Round-two runs add:
+
+- `summary.csv` and `daily_returns.csv`;
+- `annual_folds.csv`;
+- `bootstrap.json`;
+- `parameter_stability.csv`;
+- `current_signals.csv`;
+- `report.html`.
+
 ## Execution convention
 
 Signals use closes through day `t-1`, enter at the next available daily open `t`, and earn the open-`t` to open-`t+1` return. This removes the unattainable same-close fill from the first prototype. The model still does **not** simulate opening-auction slippage, bid/ask spread, market impact, or intraday execution.

--- a/projects/quant-research-platform/src/gold_research/backtest.py
+++ b/projects/quant-research-platform/src/gold_research/backtest.py
@@ -40,11 +40,10 @@ def backtest(open_price: pd.Series, signal: pd.Series, cost_bps: float = 5.0) ->
 
 
 def trade_ledger(result: pd.DataFrame) -> pd.DataFrame:
-    change = result["signal"].diff()
-    if not change.empty:
-        change.iloc[0] = result["signal"].iloc[0]
-    entries = list(np.flatnonzero(change.to_numpy() > 0))
-    exits = list(np.flatnonzero(change.to_numpy() < 0))
+    held = result["signal"].astype(float) > 0.0
+    previously_held = held.shift(1, fill_value=False)
+    entries = list(np.flatnonzero((held & ~previously_held).to_numpy()))
+    exits = list(np.flatnonzero((~held & previously_held).to_numpy()))
     records: list[dict] = []
     for entry in entries:
         exit_candidates = [candidate for candidate in exits if candidate > entry]

--- a/projects/quant-research-platform/src/gold_research/round2.py
+++ b/projects/quant-research-platform/src/gold_research/round2.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from .backtest import backtest, metrics
+from .run import _data_hash, canonical_hash, get_git_state, stable_run_id
+from .strategies import (
+    absolute_momentum_signal,
+    buy_hold_signal,
+    donchian_signal,
+    multi_horizon_momentum_signal,
+    risk_managed_trend_signal,
+    sma_signal,
+    trend_filter_signal,
+)
+from .validation import calendar_year_metrics, paired_block_bootstrap
+
+
+STRATEGY_NAMES = [
+    "buy_and_hold",
+    "sma_50_200",
+    "donchian_55_20",
+    "trend_200",
+    "momentum_252",
+    "momentum_vote_63_126_252",
+    "trend_200_vol10",
+]
+
+
+def round2_signals(close: pd.Series) -> dict[str, pd.Series]:
+    return {
+        "buy_and_hold": buy_hold_signal(close),
+        "sma_50_200": sma_signal(close, 50, 200),
+        "donchian_55_20": donchian_signal(close, 55, 20),
+        "trend_200": trend_filter_signal(close, 200),
+        "momentum_252": absolute_momentum_signal(close, 252),
+        "momentum_vote_63_126_252": multi_horizon_momentum_signal(close, (63, 126, 252), 2),
+        "trend_200_vol10": risk_managed_trend_signal(close, 200, 60, 0.10),
+    }
+
+
+def _normalize(data: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+    normalized = {}
+    for symbol, frame in data.items():
+        item = frame.copy()
+        if "Date" in item.columns:
+            item["Date"] = pd.to_datetime(item["Date"])
+            item = item.set_index("Date")
+        item.index = pd.to_datetime(item.index)
+        if not {"Open", "Close"} <= set(item.columns):
+            raise ValueError(f"{symbol} requires Open and Close columns")
+        item = item.sort_index().dropna(subset=["Open", "Close"])
+        if item.index.has_duplicates:
+            raise ValueError(f"{symbol} contains duplicate dates")
+        normalized[symbol] = item
+    return normalized
+
+
+def _parameter_signals(close: pd.Series) -> dict[str, pd.Series]:
+    signals = {}
+    for window in (150, 200, 250):
+        signals[f"trend_{window}"] = trend_filter_signal(close, window)
+    for lookback in (189, 252, 315):
+        signals[f"momentum_{lookback}"] = absolute_momentum_signal(close, lookback)
+    for entry in (50, 55, 60):
+        signals[f"donchian_{entry}_20"] = donchian_signal(close, entry, 20)
+    for target in (0.08, 0.10, 0.12):
+        signals[f"trend_200_vol{int(target * 100)}"] = risk_managed_trend_signal(close, 200, 60, target)
+    return signals
+
+
+def _next_session_signals(close: pd.Series) -> dict[str, float]:
+    next_date = close.index[-1] + pd.offsets.BDay(1)
+    extended = pd.concat([close, pd.Series([close.iloc[-1]], index=[next_date])])
+    return {name: float(signal.iloc[-1]) for name, signal in round2_signals(extended).items()}
+
+
+def _render_report(
+    run_id: str,
+    config: dict,
+    manifest: dict,
+    summary: pd.DataFrame,
+    folds: pd.DataFrame,
+    bootstrap: list[dict],
+    current: pd.DataFrame,
+) -> str:
+    base = summary[summary["cost_bps"] == config["cost_bps"]].copy()
+    view = base[["symbol", "strategy", "cagr", "max_drawdown", "sharpe", "market_exposure"]].copy()
+    for column in ["cagr", "max_drawdown", "market_exposure"]:
+        view[column] = view[column].map(lambda value: f"{value:.1%}")
+    view["sharpe"] = view["sharpe"].map(lambda value: f"{value:.2f}")
+    boot = pd.DataFrame(bootstrap)[
+        [
+            "symbol",
+            "strategy",
+            "annual_return_diff",
+            "annual_return_diff_ci_low",
+            "annual_return_diff_ci_high",
+            "sharpe_diff",
+            "sharpe_diff_ci_low",
+            "sharpe_diff_ci_high",
+        ]
+    ]
+    consistency = (
+        folds.assign(positive=lambda frame: frame["total_return"] > 0)
+        .groupby(["symbol", "strategy"], as_index=False)
+        .agg(years=("year", "count"), positive_year_rate=("positive", "mean"), median_year_return=("total_return", "median"))
+    )
+    return f"""<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Gold strategy robustness round 2</title><style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1100px;margin:auto;padding:20px;color:#172033;background:#f4f6f8}}section{{background:white;padding:16px;margin:14px 0;border-radius:10px}}.scroll{{overflow-x:auto}}table{{border-collapse:collapse;width:100%;font-size:13px}}th,td{{padding:7px;border-bottom:1px solid #ddd;text-align:right;white-space:nowrap}}th:first-child,td:first-child{{text-align:left}}code{{overflow-wrap:anywhere}}@media(max-width:390px){{body{{padding:10px}}section{{padding:12px}}}}</style></head><body>
+<h1>Gold strategy robustness: round 2</h1><p><strong>Research only:</strong> this is not a live-trading recommendation.</p>
+<section><h2>Pre-registered design</h2><ul><li>Long-only or cash; no leverage and no short selling.</li><li>Prior-close signals execute at the next daily open.</li><li>All strategies share a {config['warmup_bars']}-session warm-up.</li><li>One-way costs: {', '.join(f'{value:g}' for value in config['cost_grid_bps'])} bps.</li><li>Calendar-year pseudo-out-of-sample folds begin in {config['first_test_year']}.</li><li>Paired moving-block bootstrap: {config['bootstrap_samples']} samples, {config['bootstrap_block_size']}-session blocks.</li></ul></section>
+<section><h2>Full-period comparison</h2><div class="scroll">{view.to_html(index=False, border=0)}</div></section>
+<section><h2>Uncertainty versus buy-and-hold</h2><p>A confidence interval containing zero means the historical advantage is not statistically resolved by this test.</p><div class="scroll">{boot.to_html(index=False, border=0, float_format=lambda value: f'{value:.4f}')}</div></section>
+<section><h2>Year-by-year consistency</h2><div class="scroll">{consistency.to_html(index=False, border=0, float_format=lambda value: f'{value:.4f}')}</div></section>
+<section><h2>Next modeled session exposure</h2><div class="scroll">{current.to_html(index=False, border=0, float_format=lambda value: f'{value:.3f}')}</div></section>
+<section><h2>Provenance</h2><pre><code>{json.dumps({'run_id': run_id, 'config': config, 'data_hash': manifest['data_hash'], 'git': manifest['git']}, indent=2)}</code></pre></section>
+</body></html>"""
+
+
+def run_round2_research(
+    data: dict[str, pd.DataFrame],
+    output_root: Path,
+    *,
+    cost_bps: float = 5.0,
+    bootstrap_samples: int = 2_000,
+    bootstrap_block_size: int = 20,
+    first_test_year: int = 2010,
+    data_manifest: dict | None = None,
+) -> dict:
+    data = _normalize(data)
+    config = {
+        "version": 2,
+        "strategies": STRATEGY_NAMES,
+        "symbols": sorted(data),
+        "cost_bps": float(cost_bps),
+        "cost_grid_bps": [float(cost_bps), float(cost_bps * 2), float(cost_bps * 4)],
+        "warmup_bars": 315,
+        "first_test_year": int(first_test_year),
+        "bootstrap_samples": int(bootstrap_samples),
+        "bootstrap_block_size": int(bootstrap_block_size),
+        "bootstrap_seed": 20260816,
+        "familywise_comparisons": 12,
+        "bootstrap_alpha": 0.05 / 12,
+        "cash_return": "zero; no interest credit",
+        "execution": "prior-close signal; next-open fill; open-to-open return",
+        "parameter_neighborhoods": {
+            "trend_windows": [150, 200, 250],
+            "momentum_lookbacks": [189, 252, 315],
+            "donchian_entries": [50, 55, 60],
+            "volatility_targets": [0.08, 0.10, 0.12],
+        },
+    }
+    data_hash = _data_hash(data)
+    git = get_git_state()
+    run_id = stable_run_id(config, data_hash, canonical_hash(git))
+    run_dir = Path(output_root) / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"immutable run already exists: {run_dir}")
+    run_dir.mkdir(parents=True)
+    manifest = {
+        "run_id": run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "data_hash": data_hash,
+        "git": git,
+        "data_manifest": data_manifest,
+    }
+
+    summary_rows: list[dict] = []
+    fold_frames: list[pd.DataFrame] = []
+    bootstrap_rows: list[dict] = []
+    stability_rows: list[dict] = []
+    signal_rows: list[dict] = []
+    daily_frames: list[pd.DataFrame] = []
+
+    for symbol, frame in data.items():
+        close = frame["Close"].astype(float)
+        open_price = frame["Open"].astype(float)
+        if len(frame) <= config["warmup_bars"] + 2:
+            raise ValueError(f"{symbol} does not have enough rows for the shared warm-up")
+        evaluation_index = frame.index[config["warmup_bars"] :]
+        open_eval = open_price.reindex(evaluation_index)
+        base_results: dict[str, pd.DataFrame] = {}
+        for strategy, full_signal in round2_signals(close).items():
+            signal = full_signal.reindex(evaluation_index)
+            for cost in config["cost_grid_bps"]:
+                result = backtest(open_eval, signal, cost)
+                summary_rows.append({"symbol": symbol, "strategy": strategy, "cost_bps": cost, **metrics(result)})
+                if cost == config["cost_bps"]:
+                    base_results[strategy] = result
+                    daily = result.reset_index(names="date")
+                    daily.insert(0, "strategy", strategy)
+                    daily.insert(0, "symbol", symbol)
+                    daily_frames.append(daily)
+            folds = calendar_year_metrics(base_results[strategy]["net_return"], config["first_test_year"])
+            folds.insert(0, "strategy", strategy)
+            folds.insert(0, "symbol", symbol)
+            fold_frames.append(folds)
+
+        benchmark = base_results["buy_and_hold"]["net_return"]
+        bootstrap_start = pd.Timestamp(f"{config['first_test_year']}-01-01")
+        for strategy in STRATEGY_NAMES[1:]:
+            inference = paired_block_bootstrap(
+                base_results[strategy].loc[bootstrap_start:, "net_return"],
+                benchmark.loc[bootstrap_start:],
+                samples=config["bootstrap_samples"],
+                block_size=config["bootstrap_block_size"],
+                seed=config["bootstrap_seed"],
+                alpha=config["bootstrap_alpha"],
+            )
+            bootstrap_rows.append({"symbol": symbol, "strategy": strategy, "benchmark": "buy_and_hold", **inference})
+
+        for strategy, full_signal in _parameter_signals(close).items():
+            result = backtest(open_eval, full_signal.reindex(evaluation_index), config["cost_bps"])
+            stability_rows.append({"symbol": symbol, "strategy": strategy, **metrics(result)})
+
+        latest_date = close.index[-1]
+        next_date = latest_date + pd.offsets.BDay(1)
+        for strategy, exposure in _next_session_signals(close).items():
+            signal_rows.append(
+                {
+                    "symbol": symbol,
+                    "strategy": strategy,
+                    "latest_observed_date": latest_date,
+                    "next_model_date": next_date,
+                    "next_open_target_exposure": exposure,
+                }
+            )
+
+    summary = pd.DataFrame(summary_rows)
+    annual_folds = pd.concat(fold_frames, ignore_index=True)
+    parameter_stability = pd.DataFrame(stability_rows)
+    current_signals = pd.DataFrame(signal_rows)
+    daily_returns = pd.concat(daily_frames, ignore_index=True)
+
+    (run_dir / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+    (run_dir / "run_manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True, default=str) + "\n")
+    summary.to_csv(run_dir / "summary.csv", index=False)
+    annual_folds.to_csv(run_dir / "annual_folds.csv", index=False)
+    (run_dir / "bootstrap.json").write_text(json.dumps(bootstrap_rows, indent=2) + "\n")
+    parameter_stability.to_csv(run_dir / "parameter_stability.csv", index=False)
+    current_signals.to_csv(run_dir / "current_signals.csv", index=False)
+    daily_returns.to_csv(run_dir / "daily_returns.csv", index=False)
+    report = _render_report(run_id, config, manifest, summary, annual_folds, bootstrap_rows, current_signals)
+    (run_dir / "report.html").write_text(report)
+    return {"run_id": run_id, "run_dir": str(run_dir), "config": config}

--- a/projects/quant-research-platform/src/gold_research/strategies.py
+++ b/projects/quant-research-platform/src/gold_research/strategies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pandas as pd
 
 
@@ -24,6 +26,47 @@ def donchian_signal(close: pd.Series, entry: int = 55, exit_: int = 20) -> pd.Se
             state = 0.0
         raw.append(state)
     return pd.Series(raw, index=close.index, name="signal").shift(1).fillna(0.0)
+
+
+def trend_filter_signal(close: pd.Series, window: int = 200) -> pd.Series:
+    """Hold gold when the latest close is above its long moving average."""
+    raw = (close > close.rolling(window).mean()).astype(float)
+    return raw.shift(1).fillna(0.0).rename("signal")
+
+
+def absolute_momentum_signal(close: pd.Series, lookback: int = 252) -> pd.Series:
+    """Hold gold when its trailing return over ``lookback`` sessions is positive."""
+    raw = (close > close.shift(lookback)).astype(float)
+    return raw.shift(1).fillna(0.0).rename("signal")
+
+
+def multi_horizon_momentum_signal(
+    close: pd.Series,
+    lookbacks: tuple[int, ...] = (63, 126, 252),
+    votes_required: int = 2,
+) -> pd.Series:
+    """Hold gold when a majority of pre-registered momentum horizons are positive."""
+    if not lookbacks or not 1 <= votes_required <= len(lookbacks):
+        raise ValueError("votes_required must be between one and the number of lookbacks")
+    votes = sum((close > close.shift(lookback)).astype(int) for lookback in lookbacks)
+    raw = (votes >= votes_required).astype(float)
+    return raw.shift(1).fillna(0.0).rename("signal")
+
+
+def risk_managed_trend_signal(
+    close: pd.Series,
+    trend_window: int = 200,
+    volatility_window: int = 60,
+    target_volatility: float = 0.10,
+) -> pd.Series:
+    """Scale a long-only trend position down when trailing volatility is high."""
+    if target_volatility <= 0:
+        raise ValueError("target_volatility must be positive")
+    trend = (close > close.rolling(trend_window).mean()).astype(float)
+    realized = close.pct_change().rolling(volatility_window).std(ddof=0) * math.sqrt(252)
+    scale = target_volatility / realized.replace(0.0, pd.NA)
+    raw = trend * scale.astype(float).clip(lower=0.0, upper=1.0).fillna(0.0)
+    return raw.shift(1).fillna(0.0).rename("signal")
 
 
 def strategy_signals(close: pd.Series) -> dict[str, pd.Series]:

--- a/projects/quant-research-platform/src/gold_research/validation.py
+++ b/projects/quant-research-platform/src/gold_research/validation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+
+def _sharpe(values: np.ndarray) -> float:
+    standard_deviation = float(np.std(values, ddof=0))
+    if standard_deviation == 0.0:
+        return 0.0
+    return float(np.mean(values) / standard_deviation * math.sqrt(252))
+
+
+def calendar_year_metrics(returns: pd.Series, first_test_year: int) -> pd.DataFrame:
+    """Summarize a continuous, already-costed return path by calendar test year."""
+    clean = returns.astype(float).dropna().sort_index()
+    if not isinstance(clean.index, pd.DatetimeIndex):
+        raise ValueError("returns must have a DatetimeIndex")
+    rows = []
+    for year, values in clean.groupby(clean.index.year):
+        if int(year) < first_test_year:
+            continue
+        equity = (1.0 + values).cumprod()
+        drawdown = equity / equity.cummax().clip(lower=1.0) - 1.0
+        rows.append(
+            {
+                "year": int(year),
+                "observations": int(len(values)),
+                "total_return": float(equity.iloc[-1] - 1.0),
+                "annual_volatility": float(values.std(ddof=0) * math.sqrt(252)),
+                "sharpe": _sharpe(values.to_numpy()),
+                "max_drawdown": float(drawdown.min()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def paired_block_bootstrap(
+    strategy_returns: pd.Series,
+    benchmark_returns: pd.Series,
+    *,
+    samples: int = 2_000,
+    block_size: int = 20,
+    seed: int = 20260816,
+    alpha: float = 0.05,
+) -> dict[str, float | int]:
+    """Paired moving-block bootstrap for return and Sharpe differences."""
+    paired = pd.concat(
+        [strategy_returns.rename("strategy"), benchmark_returns.rename("benchmark")],
+        axis=1,
+        join="inner",
+    ).dropna()
+    values = paired.to_numpy(dtype=float)
+    observations = len(values)
+    if samples < 1 or block_size < 1 or observations < block_size:
+        raise ValueError("samples and block_size must be positive and enough observations are required")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    annual_return_diff = float(np.mean(values[:, 0] - values[:, 1]) * 252)
+    sharpe_diff = _sharpe(values[:, 0]) - _sharpe(values[:, 1])
+    rng = np.random.default_rng(seed)
+    blocks_needed = math.ceil(observations / block_size)
+    max_start = observations - block_size
+    annual_diffs = np.empty(samples)
+    sharpe_diffs = np.empty(samples)
+    for sample in range(samples):
+        starts = rng.integers(0, max_start + 1, size=blocks_needed)
+        indices = np.concatenate([np.arange(start, start + block_size) for start in starts])[:observations]
+        drawn = values[indices]
+        annual_diffs[sample] = np.mean(drawn[:, 0] - drawn[:, 1]) * 252
+        sharpe_diffs[sample] = _sharpe(drawn[:, 0]) - _sharpe(drawn[:, 1])
+    return {
+        "observations": observations,
+        "samples": samples,
+        "block_size": block_size,
+        "annual_return_diff": annual_return_diff,
+        "confidence_level": float(1.0 - alpha),
+        "annual_return_diff_ci_low": float(np.quantile(annual_diffs, alpha / 2.0)),
+        "annual_return_diff_ci_high": float(np.quantile(annual_diffs, 1.0 - alpha / 2.0)),
+        "probability_annual_return_diff_positive": float(np.mean(annual_diffs > 0.0)),
+        "sharpe_diff": float(sharpe_diff),
+        "sharpe_diff_ci_low": float(np.quantile(sharpe_diffs, alpha / 2.0)),
+        "sharpe_diff_ci_high": float(np.quantile(sharpe_diffs, 1.0 - alpha / 2.0)),
+        "probability_sharpe_diff_positive": float(np.mean(sharpe_diffs > 0.0)),
+    }

--- a/projects/quant-research-platform/tests/test_backtest.py
+++ b/projects/quant-research-platform/tests/test_backtest.py
@@ -51,6 +51,19 @@ def test_open_trade_is_not_counted_as_closed_or_charged_exit_cost():
     assert result["cost"].sum() == pytest.approx(0.0005)
 
 
+def test_fractional_rebalancing_does_not_create_phantom_round_trips():
+    from gold_research.backtest import trade_ledger
+
+    idx = pd.bdate_range("2024-01-01", periods=7)
+    opens = pd.Series([100, 101, 102, 103, 104, 105, 106], index=idx, dtype=float)
+    signal = pd.Series([0.0, 0.4, 0.6, 0.5, 0.8, 0.0, 0.0], index=idx)
+    ledger = trade_ledger(backtest(opens, signal, cost_bps=0))
+    assert len(ledger) == 1
+    assert ledger.iloc[0]["entry_date"] == idx[1]
+    assert ledger.iloc[0]["exit_date"] == idx[5]
+    assert not bool(ledger.iloc[0]["is_open"])
+
+
 def test_max_drawdown_includes_starting_capital_and_sortino_uses_target_downside():
     idx = pd.bdate_range("2024-01-01", periods=3)
     opens = pd.Series([100.0, 80.0, 80.0], index=idx)

--- a/projects/quant-research-platform/tests/test_round2.py
+++ b/projects/quant-research-platform/tests/test_round2.py
@@ -1,0 +1,61 @@
+import json
+
+import numpy as np
+import pandas as pd
+
+from gold_research.round2 import run_round2_research
+
+
+def synthetic_gold(seed: int, periods: int = 2400) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    index = pd.bdate_range("2005-01-03", periods=periods)
+    regime = np.where((np.arange(periods) // 300) % 2 == 0, 0.0005, -0.0001)
+    close = 100 * np.exp(np.cumsum(regime + rng.normal(0, 0.008, periods)))
+    overnight = rng.normal(0, 0.001, periods)
+    open_price = close * np.exp(overnight)
+    return pd.DataFrame({"Open": open_price, "Close": close}, index=index)
+
+
+def test_round2_run_emits_pre_registered_robustness_artifacts(tmp_path):
+    data = {"GC=F": synthetic_gold(1), "GLD": synthetic_gold(2)}
+    result = run_round2_research(
+        data,
+        tmp_path,
+        cost_bps=5.0,
+        bootstrap_samples=100,
+        first_test_year=2010,
+    )
+    run_dir = tmp_path / result["run_id"]
+    required = {
+        "config.json",
+        "run_manifest.json",
+        "summary.csv",
+        "annual_folds.csv",
+        "bootstrap.json",
+        "parameter_stability.csv",
+        "current_signals.csv",
+        "report.html",
+    }
+    assert required <= {path.name for path in run_dir.iterdir()}
+    config = json.loads((run_dir / "config.json").read_text())
+    assert config["strategies"] == [
+        "buy_and_hold",
+        "sma_50_200",
+        "donchian_55_20",
+        "trend_200",
+        "momentum_252",
+        "momentum_vote_63_126_252",
+        "trend_200_vol10",
+    ]
+    summary = pd.read_csv(run_dir / "summary.csv")
+    assert len(summary) == 2 * 7 * 3
+    assert set(summary["cost_bps"]) == {5.0, 10.0, 20.0}
+    folds = pd.read_csv(run_dir / "annual_folds.csv")
+    assert folds["year"].min() >= 2010
+    assert set(folds["strategy"]) == set(config["strategies"])
+    bootstrap = json.loads((run_dir / "bootstrap.json").read_text())
+    assert len(bootstrap) == 2 * 6
+    assert all(item["benchmark"] == "buy_and_hold" for item in bootstrap)
+    report = (run_dir / "report.html").read_text()
+    assert "Paired moving-block bootstrap" in report
+    assert "not a live-trading recommendation" in report

--- a/projects/quant-research-platform/tests/test_strategies.py
+++ b/projects/quant-research-platform/tests/test_strategies.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pandas as pd
 
-from gold_research.strategies import buy_hold_signal, donchian_signal, sma_signal
+from gold_research.strategies import (
+    absolute_momentum_signal,
+    buy_hold_signal,
+    donchian_signal,
+    multi_horizon_momentum_signal,
+    risk_managed_trend_signal,
+    sma_signal,
+    trend_filter_signal,
+)
 
 
 def prices(n=260):
@@ -27,3 +35,43 @@ def test_donchian_uses_prior_channels_and_delayed_execution():
     assert signal.index.equals(p.index)
     assert set(signal.unique()) <= {0.0, 1.0}
     pd.testing.assert_series_equal(signal.iloc[:100], donchian_signal(p.iloc[:100], 55, 20))
+
+
+def test_round2_signals_are_delayed_and_prefix_stable():
+    p = prices(420)
+    signals = [
+        trend_filter_signal(p, 200),
+        absolute_momentum_signal(p, 252),
+        multi_horizon_momentum_signal(p, (63, 126, 252), 2),
+        risk_managed_trend_signal(p, 200, 60, 0.10),
+    ]
+    prefixes = [
+        trend_filter_signal(p.iloc[:360], 200),
+        absolute_momentum_signal(p.iloc[:360], 252),
+        multi_horizon_momentum_signal(p.iloc[:360], (63, 126, 252), 2),
+        risk_managed_trend_signal(p.iloc[:360], 200, 60, 0.10),
+    ]
+    for signal, prefix in zip(signals, prefixes, strict=True):
+        assert signal.index.equals(p.index)
+        assert signal.between(0.0, 1.0).all()
+        pd.testing.assert_series_equal(signal.iloc[:360], prefix)
+
+
+def test_trend_and_momentum_do_not_use_current_close_for_current_open():
+    p = prices(320)
+    altered = p.copy()
+    altered.iloc[-1] *= 100
+    for function in [trend_filter_signal, absolute_momentum_signal]:
+        original = function(p)
+        changed = function(altered)
+        assert changed.iloc[-1] == original.iloc[-1]
+
+
+def test_risk_managed_trend_reduces_exposure_when_volatility_rises():
+    idx = pd.bdate_range("2020-01-01", periods=360)
+    calm = pd.Series(100 * np.cumprod(np.repeat(1.0002, 360)), index=idx)
+    volatile = calm.copy()
+    volatile.iloc[-80:] *= np.cumprod(np.tile([1.04, 0.97], 40))
+    calm_signal = risk_managed_trend_signal(calm, 100, 60, 0.10)
+    volatile_signal = risk_managed_trend_signal(volatile, 100, 60, 0.10)
+    assert volatile_signal.iloc[-1] < calm_signal.iloc[-1]

--- a/projects/quant-research-platform/tests/test_validation.py
+++ b/projects/quant-research-platform/tests/test_validation.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+
+from gold_research.validation import calendar_year_metrics, paired_block_bootstrap
+
+
+def test_calendar_year_metrics_preserve_continuous_return_path():
+    idx = pd.bdate_range("2019-01-01", "2022-12-31")
+    returns = pd.Series(0.0004, index=idx)
+    folds = calendar_year_metrics(returns, first_test_year=2020)
+    assert list(folds["year"]) == [2020, 2021, 2022]
+    assert (folds["observations"] > 250).all()
+    assert (folds["total_return"] > 0).all()
+
+
+def test_paired_block_bootstrap_is_deterministic_and_detects_clear_advantage():
+    idx = pd.bdate_range("2018-01-01", periods=1200)
+    benchmark = pd.Series(np.tile([0.001, -0.001], 600), index=idx)
+    strategy = benchmark + 0.0005
+    first = paired_block_bootstrap(strategy, benchmark, samples=500, block_size=20, seed=7)
+    second = paired_block_bootstrap(strategy, benchmark, samples=500, block_size=20, seed=7)
+    assert first == second
+    assert first["annual_return_diff_ci_low"] > 0
+    assert first["probability_annual_return_diff_positive"] > 0.99
+
+
+def test_paired_block_bootstrap_reports_uncertainty_for_identical_paths():
+    idx = pd.bdate_range("2018-01-01", periods=800)
+    returns = pd.Series(np.tile([0.01, -0.01], 400), index=idx)
+    result = paired_block_bootstrap(returns, returns, samples=200, block_size=20, seed=9)
+    assert result["annual_return_diff"] == 0
+    assert result["annual_return_diff_ci_low"] == 0
+    assert result["annual_return_diff_ci_high"] == 0
+
+
+def test_lower_familywise_alpha_produces_a_wider_interval():
+    rng = np.random.default_rng(11)
+    idx = pd.bdate_range("2018-01-01", periods=1200)
+    benchmark = pd.Series(rng.normal(0.0002, 0.01, len(idx)), index=idx)
+    strategy = benchmark + pd.Series(rng.normal(0.0001, 0.003, len(idx)), index=idx)
+    nominal = paired_block_bootstrap(strategy, benchmark, samples=500, block_size=20, seed=5, alpha=0.05)
+    adjusted = paired_block_bootstrap(strategy, benchmark, samples=500, block_size=20, seed=5, alpha=0.005)
+    nominal_width = nominal["annual_return_diff_ci_high"] - nominal["annual_return_diff_ci_low"]
+    adjusted_width = adjusted["annual_return_diff_ci_high"] - adjusted["annual_return_diff_ci_low"]
+    assert adjusted_width > nominal_width
+    assert adjusted["confidence_level"] == 0.995


### PR DESCRIPTION
## Summary
- add four pre-registered long-only gold strategy candidates
- add calendar-year retrospective evaluation and paired moving-block bootstrap inference
- apply Bonferroni familywise adjustment across six strategies and two gold proxies
- fix fractional-position trade counting so rebalancing is measured by turnover, not phantom round trips
- document the second-round artifacts and limitations

## Verification
- 28 pytest tests pass
- Ruff passes
- Gitleaks reports no leaks
- final immutable run: `017973108d410e3c`
- source hash: `0d64b11d24142c20d521678d4f5cd5c19ae3b997cdf01312cc776c5d286ffc2f`
- data hash: `be109e127b988435b1674b4b2e16bef818499c3b8109cd1b48337fd90d9bbedd`
- 10,000 paired 20-session block-bootstrap samples with alpha `0.05/12`
- two independent publication audits passed with no critical/high blockers

## Boundary
Research only. No broker connectivity, live-order path, leverage, or short selling. GC=F remains a vendor continuous-futures proxy, not an executable contract series.
