### PR TITLE
Ignore quant research analysis artifacts

### DIFF
--- a/projects/quant-research-platform/.gitignore
+++ b/projects/quant-research-platform/.gitignore
@@ -11,3 +11,4 @@ runs/*
 !runs/.gitkeep
 state/*
 !state/.gitkeep
+analysis/


### PR DESCRIPTION
Keep generated exploratory analysis outputs out of the source repository while preserving the versioned research code and immutable run manifests.