### PR TITLE
feat: add CMB gold snapshot adapter

### DIFF
--- a/projects/quant-research-platform/.gitignore
+++ b/projects/quant-research-platform/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 .ipynb_checkpoints/
 data/raw/*
 !data/raw/.gitkeep
+data/cmb/*
+!data/cmb/.gitkeep
 runs/*
 !runs/.gitkeep
 state/*

--- a/projects/quant-research-platform/README.md
+++ b/projects/quant-research-platform/README.md
@@ -101,6 +101,7 @@ After connecting, run `./scripts/jupyter_url.sh` on the server yourself to displ
 ./scripts/manage.sh test           # deterministic synthetic unit tests; no network dependency
 ./scripts/manage.sh lint           # Ruff
 ./scripts/manage.sh run            # Yahoo -> Prefect -> research -> MLflow
+./scripts/manage.sh cmb-snapshot   # Append CMB public SGE market snapshot
 ./scripts/manage.sh infra-down
 ```
 
@@ -108,6 +109,18 @@ The `Makefile` is a convenience alias for hosts that already have GNU Make; the 
 entry point above is canonical and needs no package beyond Bash, Python, and Docker Compose.
 
 A Yahoo/network failure raises `DataDownloadError` with the affected symbol and underlying HTTP/parse detail. Online acquisition is intentionally excluded from unit tests.
+
+## CMB public gold snapshot
+
+`./scripts/manage.sh cmb-snapshot` appends the current public CMB gold-market payload to
+`data/cmb/` as CSV and Parquet with a manifest. The endpoint exposes Shanghai Gold Exchange
+reference-market snapshots such as `Au(T+D)` and `Au99.99`.
+
+This is **not** the authenticated CMB Gold Account purchase or redemption quote, contains no
+bank bid/ask spread, and provides no historical backfill. It can be used for timestamped
+reference-market cross-checks and forward data collection, but the public snapshot may be delayed
+or stale. It must not be presented as an executable CMB Gold Account price or used alone for a
+historical strategy backtest. Each collected row stores a canonical payload checksum for provenance.
 
 ## Artifacts
 

--- a/projects/quant-research-platform/scripts/manage.sh
+++ b/projects/quant-research-platform/scripts/manage.sh
@@ -24,8 +24,12 @@ case "${1:-}" in
     docker compose exec -T -e PYTHONPATH=/workspace/src jupyter python -m gold_research.flow \
       --tracking-uri http://mlflow:5000
     ;;
+  cmb-snapshot)
+    docker compose exec -T -e PYTHONPATH=/workspace/src jupyter python -m gold_research.cmb \
+      --output data/cmb
+    ;;
   *)
-    printf 'Usage: %s {infra-up|infra-health|infra-down|test|lint|run}\n' "$0" >&2
+    printf 'Usage: %s {infra-up|infra-health|infra-down|test|lint|run|cmb-snapshot}\n' "$0" >&2
     exit 2
     ;;
 esac

--- a/projects/quant-research-platform/src/gold_research/cmb.py
+++ b/projects/quant-research-platform/src/gold_research/cmb.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import math
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import requests
+
+CMB_GOLD_API_URL = "https://m.cmbchina.com/api/rate/gold"
+SOURCE_KIND = "sge_market_snapshot_via_cmb_public_page"
+SNAPSHOT_COLUMNS = {
+    "market_timestamp",
+    "retrieved_at_utc",
+    "variety",
+    "gold_no",
+    "current_price",
+    "change",
+    "open",
+    "previous_close",
+    "high",
+    "low",
+    "average_price",
+    "trade_count",
+    "source_url",
+    "source_kind",
+    "is_executable_cmb_gold_account_quote",
+    "payload_sha256",
+}
+
+
+class CmbGoldDataError(RuntimeError):
+    """Raised when the public CMB gold market snapshot cannot be validated."""
+
+
+def _number(value: object, field: str) -> float:
+    if isinstance(value, bool):
+        raise CmbGoldDataError(f"invalid {field}: {value!r}")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise CmbGoldDataError(f"invalid {field}: {value!r}") from exc
+    if not math.isfinite(number):
+        raise CmbGoldDataError(f"invalid {field}: {value!r}")
+    return number
+
+
+def _integer(value: object, field: str) -> int:
+    number = _number(value, field)
+    if not number.is_integer() or number < 0:
+        raise CmbGoldDataError(f"invalid {field}: {value!r}")
+    return int(number)
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CmbGoldDataError(f"invalid {field}: {value!r}")
+    return value.strip()
+
+
+def parse_cmb_gold_payload(payload: dict, *, retrieved_at: datetime) -> pd.DataFrame:
+    """Parse CMB's public SGE market snapshot.
+
+    This payload contains Shanghai Gold Exchange reference-market fields. It is
+    not the authenticated CMB Gold Account purchase or redemption quote.
+    """
+
+    if not isinstance(payload, dict):
+        raise CmbGoldDataError("CMB gold API response must be a JSON object")
+    code = payload.get("returnCode")
+    if code != "SUC0000":
+        raise CmbGoldDataError(f"CMB gold API returned {code}: {payload.get('errorMsg')}")
+    body = payload.get("body")
+    if not isinstance(body, dict) or not isinstance(body.get("data"), list):
+        raise CmbGoldDataError("CMB gold API response has no body.data list")
+    try:
+        market_date = pd.Timestamp(body["time"]).date()
+    except (KeyError, TypeError, ValueError) as exc:
+        raise CmbGoldDataError("CMB gold API response has an invalid market time") from exc
+
+    retrieved = pd.Timestamp(retrieved_at)
+    if retrieved.tzinfo is None:
+        retrieved = retrieved.tz_localize("UTC")
+    else:
+        retrieved = retrieved.tz_convert("UTC")
+    payload_sha256 = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+
+    rows = []
+    for item in body["data"]:
+        if not isinstance(item, dict):
+            raise CmbGoldDataError("CMB gold API contains a non-object row")
+        try:
+            market_timestamp = pd.Timestamp(f"{market_date} {item['time']}", tz="Asia/Shanghai")
+            row = {
+                "market_timestamp": market_timestamp,
+                "retrieved_at_utc": retrieved,
+                "variety": _text(item.get("variety"), "variety"),
+                "gold_no": _text(item.get("goldNo"), "goldNo"),
+                "current_price": _number(item.get("curPrice"), "curPrice"),
+                "change": _number(item.get("upDown"), "upDown"),
+                "open": _number(item.get("open"), "open"),
+                "previous_close": _number(item.get("preClose"), "preClose"),
+                "high": _number(item.get("high"), "high"),
+                "low": _number(item.get("low"), "low"),
+                "average_price": _number(item.get("avePrice"), "avePrice"),
+                "trade_count": _integer(item.get("tradeCount"), "tradeCount"),
+                "source_url": CMB_GOLD_API_URL,
+                "source_kind": SOURCE_KIND,
+                "is_executable_cmb_gold_account_quote": False,
+                "payload_sha256": payload_sha256,
+            }
+        except KeyError as exc:
+            raise CmbGoldDataError(f"CMB gold API row is missing {exc.args[0]}") from exc
+        rows.append(row)
+
+    if not rows:
+        raise CmbGoldDataError("CMB gold API response contains no market rows")
+    return pd.DataFrame(rows)
+
+
+def _validate_snapshot_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    clean = frame.copy()
+    missing = SNAPSHOT_COLUMNS - set(clean.columns)
+    if missing:
+        raise CmbGoldDataError(f"snapshot frame is missing columns: {sorted(missing)}")
+    if clean.empty:
+        raise CmbGoldDataError("snapshot frame is empty")
+    if not clean["source_kind"].eq(SOURCE_KIND).all():
+        raise CmbGoldDataError("snapshot source_kind does not match the CMB SGE adapter")
+    if not clean["source_url"].eq(CMB_GOLD_API_URL).all():
+        raise CmbGoldDataError("snapshot source_url does not match the CMB public API")
+    classification = clean["is_executable_cmb_gold_account_quote"]
+    if not classification.map(lambda value: isinstance(value, (bool, np.bool_)) and not bool(value)).all():
+        raise CmbGoldDataError("snapshot is incorrectly classified as an executable CMB quote")
+    if not clean["payload_sha256"].astype(str).str.fullmatch(r"[0-9a-f]{64}").all():
+        raise CmbGoldDataError("snapshot payload_sha256 is invalid")
+    for column in [
+        "current_price",
+        "change",
+        "open",
+        "previous_close",
+        "high",
+        "low",
+        "average_price",
+        "trade_count",
+    ]:
+        values = pd.to_numeric(clean[column], errors="coerce")
+        if values.isna().any() or not values.map(math.isfinite).all():
+            raise CmbGoldDataError(f"snapshot {column} contains invalid numbers")
+        clean[column] = values
+    if (clean["trade_count"] < 0).any() or not clean["trade_count"].map(
+        lambda value: float(value).is_integer()
+    ).all():
+        raise CmbGoldDataError("snapshot trade_count must contain non-negative integers")
+    clean["trade_count"] = clean["trade_count"].astype(int)
+    for column in ["gold_no", "variety"]:
+        if clean[column].map(lambda value: not isinstance(value, str) or not value.strip()).any():
+            raise CmbGoldDataError(f"snapshot {column} identifiers must be non-empty strings")
+    try:
+        clean["market_timestamp"] = pd.to_datetime(clean["market_timestamp"], utc=True).dt.tz_convert(
+            "Asia/Shanghai"
+        )
+        clean["retrieved_at_utc"] = pd.to_datetime(clean["retrieved_at_utc"], utc=True)
+    except (TypeError, ValueError) as exc:
+        raise CmbGoldDataError(f"snapshot timestamps are invalid: {exc}") from exc
+    if clean[["market_timestamp", "retrieved_at_utc"]].isna().any().any():
+        raise CmbGoldDataError("snapshot timestamps must not be missing")
+    return clean
+
+
+def _reject_conflicting_duplicates(frame: pd.DataFrame) -> None:
+    key = ["market_timestamp", "gold_no"]
+    duplicates = frame[frame.duplicated(subset=key, keep=False)]
+    comparison_columns = [
+        "variety",
+        "current_price",
+        "change",
+        "open",
+        "previous_close",
+        "high",
+        "low",
+        "average_price",
+        "trade_count",
+        "source_url",
+        "source_kind",
+        "is_executable_cmb_gold_account_quote",
+    ]
+    for _, group in duplicates.groupby(key, dropna=False):
+        if any(group[column].nunique(dropna=False) > 1 for column in comparison_columns):
+            raise CmbGoldDataError("conflicting duplicate CMB market rows")
+
+
+def _load_existing_snapshot(csv_path: Path, parquet_path: Path, manifest_path: Path) -> pd.DataFrame:
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        csv_digest = hashlib.sha256(csv_path.read_bytes()).hexdigest()
+        parquet_digest = hashlib.sha256(parquet_path.read_bytes()).hexdigest()
+        if manifest.get("csv_sha256") != csv_digest or manifest.get("parquet_sha256") != parquet_digest:
+            raise CmbGoldDataError("existing CMB snapshot integrity hash mismatch")
+        csv_frame = pd.read_csv(csv_path)
+        parquet_frame = pd.read_parquet(parquet_path)
+        if len(csv_frame) != len(parquet_frame) or manifest.get("rows") != len(csv_frame):
+            raise CmbGoldDataError("existing CMB snapshot integrity row-count mismatch")
+        return _validate_snapshot_frame(csv_frame)
+    except CmbGoldDataError:
+        raise
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        raise CmbGoldDataError(f"existing CMB snapshot integrity check failed: {exc}") from exc
+
+
+def fetch_cmb_gold_snapshot(timeout: int = 20) -> pd.DataFrame:
+    """Fetch and parse the current public CMB SGE market snapshot."""
+
+    try:
+        response = requests.get(
+            CMB_GOLD_API_URL,
+            timeout=timeout,
+            headers={
+                "User-Agent": "gold-quant-research/0.1",
+                "Referer": "https://m.cmbchina.com/goldrate.html",
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise CmbGoldDataError(f"CMB gold API request failed: {exc}") from exc
+    return parse_cmb_gold_payload(payload, retrieved_at=datetime.now(timezone.utc))
+
+
+def append_cmb_gold_snapshot(frame: pd.DataFrame, output_dir: Path) -> dict:
+    """Append one public-market snapshot and persist deterministic artifacts."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "cmb_sge_gold_snapshots.csv"
+    parquet_path = output_dir / "cmb_sge_gold_snapshots.parquet"
+    manifest_path = output_dir / "data_manifest.json"
+    lock_path = output_dir / ".cmb_snapshot.lock"
+
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            return _append_cmb_gold_snapshot_locked(frame, csv_path, parquet_path, manifest_path)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _append_cmb_gold_snapshot_locked(
+    frame: pd.DataFrame, csv_path: Path, parquet_path: Path, manifest_path: Path
+) -> dict:
+
+    existing_paths = [csv_path.exists(), parquet_path.exists(), manifest_path.exists()]
+    if any(existing_paths) and not all(existing_paths):
+        raise CmbGoldDataError("CMB snapshot artifacts are incomplete; refusing to append")
+
+    clean = _validate_snapshot_frame(frame)
+
+    if csv_path.exists():
+        existing = _load_existing_snapshot(csv_path, parquet_path, manifest_path)
+        clean = pd.concat([existing, clean], ignore_index=True)
+        clean = _validate_snapshot_frame(clean)
+
+    _reject_conflicting_duplicates(clean)
+    clean = (
+        clean.drop_duplicates(subset=["market_timestamp", "gold_no"], keep="last")
+        .sort_values(["market_timestamp", "gold_no"])
+        .reset_index(drop=True)
+    )
+    with tempfile.TemporaryDirectory(dir=csv_path.parent) as staging_dir:
+        staging = Path(staging_dir)
+        staged_csv = staging / csv_path.name
+        staged_parquet = staging / parquet_path.name
+        staged_manifest = staging / manifest_path.name
+        clean.to_csv(staged_csv, index=False, float_format="%.10g")
+        clean.to_parquet(staged_parquet, index=False)
+
+        csv_digest = hashlib.sha256(staged_csv.read_bytes()).hexdigest()
+        parquet_digest = hashlib.sha256(staged_parquet.read_bytes()).hexdigest()
+        manifest = {
+            "source_url": CMB_GOLD_API_URL,
+            "source_kind": SOURCE_KIND,
+            "is_executable_cmb_gold_account_quote": False,
+            "rows": int(len(clean)),
+            "data_start": clean["market_timestamp"].min().isoformat(),
+            "data_end": clean["market_timestamp"].max().isoformat(),
+            "latest_retrieved_at_utc": clean["retrieved_at_utc"].max().isoformat(),
+            "latest_payload_sha256": clean.sort_values("retrieved_at_utc").iloc[-1]["payload_sha256"],
+            "csv": str(csv_path),
+            "parquet": str(parquet_path),
+            "csv_sha256": csv_digest,
+            "parquet_sha256": parquet_digest,
+        }
+        staged_manifest.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        os.replace(staged_csv, csv_path)
+        os.replace(staged_parquet, parquet_path)
+        os.replace(staged_manifest, manifest_path)
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect CMB's public SGE gold market snapshot")
+    parser.add_argument("--output", type=Path, default=Path("data/cmb"))
+    args = parser.parse_args()
+    manifest = append_cmb_gold_snapshot(fetch_cmb_gold_snapshot(), args.output)
+    print(json.dumps({"rows": manifest["rows"], "data_end": manifest["data_end"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/quant-research-platform/tests/test_cmb.py
+++ b/projects/quant-research-platform/tests/test_cmb.py
@@ -1,0 +1,203 @@
+import json
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from gold_research.cmb import CmbGoldDataError, append_cmb_gold_snapshot, parse_cmb_gold_payload
+
+
+@pytest.fixture
+def cmb_payload():
+    return {
+        "returnCode": "SUC0000",
+        "errorMsg": None,
+        "body": {
+            "time": "2026-08-17 09:41",
+            "data": [
+                {
+                    "variety": "Au(T+D)",
+                    "curPrice": "952.40",
+                    "upDown": "12.77",
+                    "open": "947.50",
+                    "preClose": "940.44",
+                    "high": "956.28",
+                    "low": "946.50",
+                    "avePrice": "951.01",
+                    "tradeCount": "13004",
+                    "time": "09:41:50",
+                    "goldNo": "AUTD",
+                },
+                {
+                    "variety": "Au99.99",
+                    "curPrice": "953.00",
+                    "upDown": "12.28",
+                    "open": "946.00",
+                    "preClose": "940.72",
+                    "high": "956.00",
+                    "low": "946.00",
+                    "avePrice": "954.13",
+                    "tradeCount": "71392",
+                    "time": "09:41:46",
+                    "goldNo": "AU9999",
+                },
+            ],
+        },
+    }
+
+
+def test_parse_cmb_gold_payload_labels_sge_reference_not_bank_execution(cmb_payload):
+    retrieved_at = datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc)
+    frame = parse_cmb_gold_payload(cmb_payload, retrieved_at=retrieved_at)
+
+    assert list(frame["gold_no"]) == ["AUTD", "AU9999"]
+    assert frame.loc[1, "current_price"] == pytest.approx(953.00)
+    assert frame.loc[0, "previous_close"] == pytest.approx(940.44)
+    assert frame.loc[0, "trade_count"] == 13004
+    assert frame["source_kind"].unique().tolist() == ["sge_market_snapshot_via_cmb_public_page"]
+    assert not frame["is_executable_cmb_gold_account_quote"].any()
+    assert frame["payload_sha256"].str.len().unique().tolist() == [64]
+    assert frame["market_timestamp"].dt.tz is not None
+
+
+def test_parse_cmb_gold_payload_rejects_unsuccessful_response():
+    with pytest.raises(CmbGoldDataError, match="ERR0001"):
+        parse_cmb_gold_payload(
+            {"returnCode": "ERR0001", "errorMsg": "unavailable", "body": None},
+            retrieved_at=datetime.now(timezone.utc),
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda payload: [], "JSON object"),
+        (lambda payload: {**payload, "body": {**payload["body"], "data": [{**payload["body"]["data"][0], "curPrice": "NaN"}]}}, "curPrice"),
+        (lambda payload: {**payload, "body": {**payload["body"], "data": [{**payload["body"]["data"][0], "curPrice": True}]}}, "curPrice"),
+        (
+            lambda payload: {
+                **payload,
+                "body": {
+                    **payload["body"],
+                    "data": [{**payload["body"]["data"][0], "tradeCount": "1.5"}],
+                },
+            },
+            "tradeCount",
+        ),
+        (
+            lambda payload: {
+                **payload,
+                "body": {**payload["body"], "data": [{**payload["body"]["data"][0], "tradeCount": False}]},
+            },
+            "tradeCount",
+        ),
+        (
+            lambda payload: {
+                **payload,
+                "body": {**payload["body"], "data": [{**payload["body"]["data"][0], "goldNo": None}]},
+            },
+            "goldNo",
+        ),
+        (
+            lambda payload: {
+                **payload,
+                "body": {**payload["body"], "data": [{**payload["body"]["data"][0], "variety": None}]},
+            },
+            "variety",
+        ),
+    ],
+)
+def test_parse_cmb_gold_payload_rejects_malformed_numeric_data(cmb_payload, mutate, message):
+    with pytest.raises(CmbGoldDataError, match=message):
+        parse_cmb_gold_payload(
+            mutate(cmb_payload),
+            retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+        )
+
+
+def test_failed_parquet_write_does_not_leave_partial_snapshot_files(tmp_path, cmb_payload, monkeypatch):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+
+    def fail_parquet(*args, **kwargs):
+        raise RuntimeError("simulated parquet failure")
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", fail_parquet)
+    with pytest.raises(RuntimeError, match="simulated parquet failure"):
+        append_cmb_gold_snapshot(frame, tmp_path)
+
+    assert not (tmp_path / "cmb_sge_gold_snapshots.csv").exists()
+    assert not (tmp_path / "cmb_sge_gold_snapshots.parquet").exists()
+    assert not (tmp_path / "data_manifest.json").exists()
+
+
+def test_append_rejects_mismatched_source_provenance(tmp_path, cmb_payload):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+    frame.loc[0, "source_kind"] = "unrelated_source"
+
+    with pytest.raises(CmbGoldDataError, match="source_kind"):
+        append_cmb_gold_snapshot(frame, tmp_path)
+
+
+@pytest.mark.parametrize("column", ["market_timestamp", "retrieved_at_utc"])
+def test_append_rejects_missing_timestamps(tmp_path, cmb_payload, column):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+    frame.loc[0, column] = pd.NaT
+
+    with pytest.raises(CmbGoldDataError, match="timestamp"):
+        append_cmb_gold_snapshot(frame, tmp_path)
+
+
+def test_append_rejects_conflicting_duplicate_market_rows(tmp_path, cmb_payload):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+    conflict = frame.iloc[[0]].copy()
+    conflict.loc[:, "current_price"] = 999.0
+
+    with pytest.raises(CmbGoldDataError, match="conflicting duplicate"):
+        append_cmb_gold_snapshot(pd.concat([frame, conflict], ignore_index=True), tmp_path)
+
+
+def test_append_rejects_tampered_existing_artifacts(tmp_path, cmb_payload):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+    append_cmb_gold_snapshot(frame, tmp_path)
+    csv_path = tmp_path / "cmb_sge_gold_snapshots.csv"
+    csv_path.write_text(csv_path.read_text() + "tampered\n")
+
+    with pytest.raises(CmbGoldDataError, match="integrity"):
+        append_cmb_gold_snapshot(frame, tmp_path)
+
+
+def test_append_cmb_gold_snapshot_is_idempotent_and_writes_manifest(tmp_path, cmb_payload):
+    frame = parse_cmb_gold_payload(
+        cmb_payload,
+        retrieved_at=datetime(2026, 8, 17, 1, 42, tzinfo=timezone.utc),
+    )
+    result = append_cmb_gold_snapshot(frame, tmp_path)
+    repeated = append_cmb_gold_snapshot(frame, tmp_path)
+
+    csv_frame = pd.read_csv(tmp_path / "cmb_sge_gold_snapshots.csv")
+    parquet_frame = pd.read_parquet(tmp_path / "cmb_sge_gold_snapshots.parquet")
+    manifest = json.loads((tmp_path / "data_manifest.json").read_text())
+
+    assert result["rows"] == 2
+    assert repeated["rows"] == 2
+    assert len(csv_frame) == len(parquet_frame) == 2
+    assert manifest["source_kind"] == "sge_market_snapshot_via_cmb_public_page"
+    assert manifest["is_executable_cmb_gold_account_quote"] is False
+    assert manifest["rows"] == 2
+    assert len(manifest["csv_sha256"]) == 64
+    assert len(manifest["latest_payload_sha256"]) == 64


### PR DESCRIPTION
## Summary
- add a public CMB gold-market snapshot adapter for SGE instruments such as `Au(T+D)` and `Au99.99`
- persist append-only CSV/Parquet snapshots with payload/file hashes, strict provenance validation, and serialized writers
- reject malformed identifiers, timestamps, non-finite/boolean numeric values, conflicting duplicate rows, and tampered prior artifacts
- add `./scripts/manage.sh cmb-snapshot` and document the boundary from authenticated CMB Gold Account buy/redeem prices
- ignore runtime CMB market data while retaining the directory scaffold

## Validation
- [x] verified tests failed before each implementation cycle
- [x] 45 pytest tests pass in the authoritative `gold-quant-research:0.1.0` container
- [x] Ruff passes
- [x] Gitleaks reports no leaks
- [x] live API collection succeeds from `feng-learn`; CSV and manifest hashes reconcile
- [x] cross-process eight-writer probe preserves all 16 unique instrument/timestamp rows
- [x] serialization failure leaves no partial first-generation files

## Safety boundary
This adapter consumes the public CMB SGE reference-market endpoint. It is not an authenticated CMB Gold Account execution quote, contains no bank bid/ask spread, and is not broker or order connectivity. The public snapshot may be delayed or stale and has no historical backfill.
