### PR TITLE
Reject weak quant candidates and add Agricultural Bank trend evidence runner

### DIFF
--- a/projects/quant-research-platform/Dockerfile
+++ b/projects/quant-research-platform/Dockerfile
@@ -6,7 +6,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git=1:2.39.5-0+deb12u3 \
+    && apt-get install -y --no-install-recommends \
+        fonts-wqy-zenhei=0.9.45-8 \
+        git=1:2.39.5-0+deb12u3 \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --uid 1000 --shell /bin/bash research
 

--- a/projects/quant-research-platform/README.md
+++ b/projects/quant-research-platform/README.md
@@ -162,7 +162,7 @@ immutable run records development and holdout summaries, cost stress,
 annual returns, paired block-bootstrap uncertainty, daily returns, trades, a
 trade-by-trade cumulative return path, an SVG price chart with modeled buy/sell
 points and cumulative strategy versus buy-and-hold returns, the latest modeled
-action, configuration, provenance, and a mobile-readable HTML report. The
+action, configuration, provenance, and a Chinese mobile-readable HTML report. The
 holdout remains retrospective because it has now been inspected; only future
 paper observation can provide genuinely unseen evidence.
 

--- a/projects/quant-research-platform/README.md
+++ b/projects/quant-research-platform/README.md
@@ -127,44 +127,50 @@ forward return because that return is only known at the test-start open.
 `markers.csv` records fractional `ADD`/`REDUCE` rebalances that incur costs,
 while `trades.csv` remains a zero-to-positive round-trip ledger.
 
-## Agricultural Bank breakout study
+## Agricultural Bank Round-2 evidence study
 
-`gold_research.abc.run_abc_trend_research` implements the literal long-or-cash
-"buy strength, sell weakness" interpretation for Agricultural Bank of China
-(`601288.SS`). It compares four fixed Donchian breakout pairs (`20/10`, `40/20`,
-`60/20`, and `120/40`) using only data through 2022, freezes the balanced
-CAGR/Sharpe/Calmar rank winner, and evaluates that rule on a retrospective
-2023+ holdout against buy-and-hold.
+`gold_research.abc_round2_study.run_abc_round2_study` runs the frozen Round-2
+protocol for Agricultural Bank of China (`601288.SS`) and six predeclared bank
+peers. It evaluates exactly four public-formula long-or-cash candidates after
+each symbol's own 315-session warm-up. There is no parameter search, candidate
+selection, or forced winner.
 
-Yahoo's adjusted-close factor is applied to every OHLC field so both execution
-prices and held returns share one total-return scale. Base A-share friction is
-modeled asymmetrically at 8 bps on buys and 13 bps on sells, with a 20/25 bps
-stress case. Signals use the completed close and execute at the next adjusted
-open. The module has no broker or live-order path.
+Every manifest entry is bound to the exact symbol's canonical Yahoo chart URL
+and verified against the referenced CSV checksum, row count, date range, and
+parsed contents. Session dates are normalized to Shanghai dates, and bars on or
+after the analysis date are excluded before scoring. Yahoo's adjusted-close
+factor puts all OHLC fields on one total-return scale. The base 8/13 bps and
+stress 20/25 bps cost cases are optimistic comparability scenarios, not claims
+of real fill completeness.
 
 ```python
 from pathlib import Path
 
-from gold_research.abc import run_abc_trend_research
+from gold_research.abc_round2_study import run_abc_round2_study
 
-result = run_abc_trend_research(
-    agricultural_bank_frame,
-    Path("runs/agricultural-bank"),
-    symbol="601288.SS",
-    data_manifest=verified_manifest,
-    holdout_start="2023-01-01",
+result = run_abc_round2_study(
+    data_dir=Path("data/agricultural-bank-round2"),
+    output_root=Path("runs/agricultural-bank-round2"),
+    analysis_date="2026-08-20T13:00:00+08:00",
+    protocol_path=Path("protocol.yaml"),
 )
 ```
 
-The runner verifies the Yahoo symbol URL, source CSV checksum, row count, date
-range, and exact canonical frame contents before the study begins. Each
-immutable run records development and holdout summaries, cost stress,
-annual returns, paired block-bootstrap uncertainty, daily returns, trades, a
-trade-by-trade cumulative return path, an SVG price chart with modeled buy/sell
-points and cumulative strategy versus buy-and-hold returns, the latest modeled
-action, configuration, provenance, and a Chinese mobile-readable HTML report. The
-holdout remains retrospective because it has now been inspected; only future
-paper observation can provide genuinely unseen evidence.
+The runner applies every promotion gate independently to all four candidates.
+`execution_complete` defaults to `False`, so the execution-completeness gate
+fails until separate fill evidence exists. Target-only evidence includes exact
+circular-shift timing placebos, complete four-calendar-year blocks, every
+modeled trade, daily returns, and a next-open target derived only from the last
+completed real close. Peer validation compares each rule with each peer's own
+buy-and-hold Sharpe.
+
+Publishing uses a temporary sibling directory and atomic rename. The immutable
+run ID binds canonical configuration, completed normalized data, protocol bytes,
+and Git/source state. The non-HTML artifact contract contains configuration and
+provenance JSON, a four-row trial registry, candidate and benchmark summaries,
+peer validation, target daily returns and trades, subperiods, timing results,
+independent gate decisions, and current modeled signals. The study remains
+retrospective and research-only; it has no broker or live-order path.
 
 ## Execution convention
 

--- a/projects/quant-research-platform/README.md
+++ b/projects/quant-research-platform/README.md
@@ -127,6 +127,45 @@ forward return because that return is only known at the test-start open.
 `markers.csv` records fractional `ADD`/`REDUCE` rebalances that incur costs,
 while `trades.csv` remains a zero-to-positive round-trip ledger.
 
+## Agricultural Bank breakout study
+
+`gold_research.abc.run_abc_trend_research` implements the literal long-or-cash
+"buy strength, sell weakness" interpretation for Agricultural Bank of China
+(`601288.SS`). It compares four fixed Donchian breakout pairs (`20/10`, `40/20`,
+`60/20`, and `120/40`) using only data through 2022, freezes the balanced
+CAGR/Sharpe/Calmar rank winner, and evaluates that rule on a retrospective
+2023+ holdout against buy-and-hold.
+
+Yahoo's adjusted-close factor is applied to every OHLC field so both execution
+prices and held returns share one total-return scale. Base A-share friction is
+modeled asymmetrically at 8 bps on buys and 13 bps on sells, with a 20/25 bps
+stress case. Signals use the completed close and execute at the next adjusted
+open. The module has no broker or live-order path.
+
+```python
+from pathlib import Path
+
+from gold_research.abc import run_abc_trend_research
+
+result = run_abc_trend_research(
+    agricultural_bank_frame,
+    Path("runs/agricultural-bank"),
+    symbol="601288.SS",
+    data_manifest=verified_manifest,
+    holdout_start="2023-01-01",
+)
+```
+
+The runner verifies the Yahoo symbol URL, source CSV checksum, row count, date
+range, and exact canonical frame contents before the study begins. Each
+immutable run records development and holdout summaries, cost stress,
+annual returns, paired block-bootstrap uncertainty, daily returns, trades, a
+trade-by-trade cumulative return path, an SVG price chart with modeled buy/sell
+points and cumulative strategy versus buy-and-hold returns, the latest modeled
+action, configuration, provenance, and a mobile-readable HTML report. The
+holdout remains retrospective because it has now been inspected; only future
+paper observation can provide genuinely unseen evidence.
+
 ## Execution convention
 
 Signals use closes through day `t-1`, enter at the next available daily open `t`, and earn the open-`t` to open-`t+1` return. This removes the unattainable same-close fill from the first prototype. The model still does **not** simulate opening-auction slippage, bid/ask spread, market impact, or intraday execution.

--- a/projects/quant-research-platform/src/gold_research/abc.py
+++ b/projects/quant-research-platform/src/gold_research/abc.py
@@ -18,6 +18,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib import font_manager
 
 from .backtest import backtest, metrics, trade_ledger
 from .round3 import completed_signal_close
@@ -40,6 +41,22 @@ ABC_PARAMETERS = {
 }
 ABC_SYMBOL = "601288.SS"
 ABC_HOLDOUT_START = pd.Timestamp("2023-01-01")
+CJK_FONT_PATH = Path("/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
+if CJK_FONT_PATH.is_file():
+    font_manager.fontManager.addfont(str(CJK_FONT_PATH))
+    CJK_FONT_FAMILY = font_manager.FontProperties(fname=str(CJK_FONT_PATH)).get_name()
+else:
+    CJK_FONT_FAMILY = None
+
+
+STRATEGY_LABELS_ZH = {
+    "buy_and_hold": "买入并持有",
+    "breakout_20_10": "20日突破 / 10日退出",
+    "breakout_40_20": "40日突破 / 20日退出",
+    "breakout_60_20": "60日突破 / 20日退出",
+    "breakout_120_40": "120日突破 / 40日退出",
+}
+ACTION_LABELS_ZH = {"BUY": "买入", "SELL": "卖出", "HOLD": "继续持有", "CASH": "空仓等待"}
 
 
 def _session_index(index: pd.Index) -> pd.DatetimeIndex:
@@ -228,8 +245,16 @@ def _strategy_chart(
     trade_path: pd.DataFrame,
     strategy_name: str,
 ) -> str:
-    """Render adjusted price transitions and costed cumulative-return paths."""
-    with plt.rc_context({"svg.hashsalt": "abc-breakout-trend-v1"}):
+    """Render a Chinese-labeled chart of transactions and cumulative returns."""
+    if CJK_FONT_FAMILY is None:
+        raise RuntimeError(f"CJK font is required to render the Chinese chart: {CJK_FONT_PATH}")
+    entry_window, exit_window = ABC_PARAMETERS[strategy_name]
+    chart_context = {
+        "svg.hashsalt": "abc-breakout-trend-v1",
+        "font.family": CJK_FONT_FAMILY,
+        "axes.unicode_minus": False,
+    }
+    with plt.rc_context(chart_context):
         figure, axes = plt.subplots(2, 1, figsize=(11, 7.5), sharex=True, constrained_layout=True)
         price_axis, return_axis = axes
         price_axis.plot(
@@ -237,7 +262,7 @@ def _strategy_chart(
             holdout["Close"],
             color="#25364d",
             linewidth=1.35,
-            label="Adjusted close",
+            label="农业银行复权收盘价",
         )
         if not trade_path.empty:
             price_axis.scatter(
@@ -248,7 +273,7 @@ def _strategy_chart(
                 color="#16855b",
                 edgecolors="white",
                 linewidths=0.6,
-                label="BUY",
+                label="买入（下一交易日开盘）",
                 zorder=3,
             )
             closed = trade_path.loc[~trade_path["is_open"].astype(bool)]
@@ -261,13 +286,27 @@ def _strategy_chart(
                     color="#c93f3f",
                     edgecolors="white",
                     linewidths=0.6,
-                    label="SELL",
+                    label="卖出（下一交易日开盘）",
                     zorder=3,
                 )
-        price_axis.set_title("Agricultural Bank adjusted price with modeled transitions")
-        price_axis.set_ylabel("Adjusted price (CNY)")
+        price_axis.set_title("农业银行复权股价与策略买卖点")
+        price_axis.set_ylabel("复权价格（元）")
         price_axis.grid(alpha=0.22)
         price_axis.legend(loc="upper left", ncols=3, frameon=False)
+        price_axis.text(
+            0.985,
+            0.035,
+            f"买入：收盘价突破前{entry_window}日最高收盘价\n"
+            "→ 下一交易日开盘，按策略资金100%买入\n"
+            f"卖出：收盘价跌破前{exit_window}日最低收盘价\n"
+            "→ 下一交易日开盘，全部卖出",
+            transform=price_axis.transAxes,
+            ha="right",
+            va="bottom",
+            fontsize=10.5,
+            color="#172033",
+            bbox={"boxstyle": "round,pad=0.55", "facecolor": "#f7f9fc", "edgecolor": "#b8c2d1", "alpha": 0.96},
+        )
 
         strategy_curve = (strategy_result["equity_net"] - 1.0) * 100.0
         benchmark_curve = (benchmark_result["equity_net"] - 1.0) * 100.0
@@ -276,19 +315,19 @@ def _strategy_chart(
             strategy_curve,
             color="#405cf5",
             linewidth=1.7,
-            label=f"{strategy_name} after costs",
+            label=f"{STRATEGY_LABELS_ZH[strategy_name]}（已扣交易成本）",
         )
         return_axis.plot(
             benchmark_curve.index,
             benchmark_curve,
             color="#8a94a6",
             linewidth=1.25,
-            label="Buy-and-hold after costs",
+            label="买入并持有（已扣交易成本）",
         )
         return_axis.axhline(0.0, color="#98a2b3", linewidth=0.8)
-        return_axis.set_title("Cumulative return")
-        return_axis.set_ylabel("Return (%)")
-        return_axis.set_xlabel("Date")
+        return_axis.set_title("累计收益率")
+        return_axis.set_ylabel("累计收益率（%）")
+        return_axis.set_xlabel("日期")
         return_axis.grid(alpha=0.22)
         return_axis.legend(loc="upper left", frameon=False)
         for curve, color in ((strategy_curve, "#405cf5"), (benchmark_curve, "#687386")):
@@ -305,7 +344,15 @@ def _strategy_chart(
         buffer = io.StringIO()
         figure.savefig(buffer, format="svg", metadata={"Date": None})
         plt.close(figure)
-    return buffer.getvalue()
+    svg = buffer.getvalue()
+    svg_start = svg.find("<svg")
+    svg_open_end = svg.find(">", svg_start) + 1
+    description = (
+        "<title>农业银行趋势交易买卖点与累计收益率</title>"
+        f"<desc>买入：收盘价突破前{entry_window}日最高收盘价，下一交易日开盘按策略资金100%买入；"
+        f"卖出：收盘价跌破前{exit_window}日最低收盘价，下一交易日开盘全部卖出。</desc>"
+    )
+    return svg[:svg_open_end] + description + svg[svg_open_end:]
 
 
 def _latest_action(close: pd.Series, candidate: str) -> dict:
@@ -347,6 +394,7 @@ def _render_report(
     chart_svg: str,
 ) -> str:
     best = config["best_frozen_candidate"]
+    entry_window, exit_window = ABC_PARAMETERS[best]
     holdout_view = holdout.loc[
         :, ["candidate", "cumulative_return", "cagr", "max_drawdown", "sharpe", "calmar"]
     ].copy()
@@ -354,14 +402,15 @@ def _render_report(
         holdout_view[column] = holdout_view[column].map(_format_percent)
     for column in ("sharpe", "calmar"):
         holdout_view[column] = holdout_view[column].map(lambda value: f"{value:.2f}")
+    holdout_view["candidate"] = holdout_view["candidate"].map(STRATEGY_LABELS_ZH)
     holdout_view = holdout_view.rename(
         columns={
-            "candidate": "Strategy",
-            "cumulative_return": "Cumulative return",
-            "cagr": "CAGR",
-            "max_drawdown": "Maximum drawdown",
-            "sharpe": "Sharpe",
-            "calmar": "Calmar",
+            "candidate": "策略",
+            "cumulative_return": "累计收益率",
+            "cagr": "年化收益率",
+            "max_drawdown": "最大回撤",
+            "sharpe": "夏普比率",
+            "calmar": "卡玛比率",
         }
     )
     development_view = development.loc[
@@ -371,24 +420,26 @@ def _render_report(
         development_view[column] = development_view[column].map(_format_percent)
     for column in ("sharpe", "calmar", "turnover"):
         development_view[column] = development_view[column].map(lambda value: f"{value:.2f}")
+    development_view["candidate"] = development_view["candidate"].map(STRATEGY_LABELS_ZH)
     development_view = development_view.rename(
         columns={
-            "candidate": "Strategy",
-            "cagr": "CAGR",
-            "max_drawdown": "Maximum drawdown",
-            "sharpe": "Sharpe",
-            "calmar": "Calmar",
-            "turnover": "Turnover",
+            "candidate": "策略",
+            "cagr": "年化收益率",
+            "max_drawdown": "最大回撤",
+            "sharpe": "夏普比率",
+            "calmar": "卡玛比率",
+            "turnover": "换手次数",
         }
     )
     annual_view = annual.pivot(index="year", columns="candidate", values="total_return").reset_index()
     for column in annual_view.columns[1:]:
         annual_view[column] = annual_view[column].map(_format_percent)
+    annual_view = annual_view.rename(columns={"year": "年份", **STRATEGY_LABELS_ZH})
     trade_view = trade_path.loc[
         :, ["entry_date", "entry_price", "exit_date", "exit_price", "trade_return", "cumulative_return"]
     ].copy()
     trade_view["entry_date"] = pd.to_datetime(trade_view["entry_date"]).dt.date.astype(str)
-    trade_view["exit_date"] = pd.to_datetime(trade_view["exit_date"]).dt.date.astype("string").fillna("OPEN")
+    trade_view["exit_date"] = pd.to_datetime(trade_view["exit_date"]).dt.date.astype("string").fillna("持仓中")
     for column in ("entry_price", "exit_price"):
         trade_view[column] = trade_view[column].map(
             lambda value: "—" if pd.isna(value) else f"{float(value):.3f}"
@@ -397,27 +448,28 @@ def _render_report(
         trade_view[column] = trade_view[column].map(_format_percent)
     trade_view = trade_view.rename(
         columns={
-            "entry_date": "Buy date",
-            "entry_price": "Buy price",
-            "exit_date": "Sell date",
-            "exit_price": "Sell price",
-            "trade_return": "Trade return",
-            "cumulative_return": "Cumulative return",
+            "entry_date": "买入日期",
+            "entry_price": "买入价",
+            "exit_date": "卖出日期",
+            "exit_price": "卖出价",
+            "trade_return": "单笔收益率",
+            "cumulative_return": "卖出后累计收益率",
         }
     )
     chart_data = base64.b64encode(chart_svg.encode()).decode()
     strategy_row = holdout.loc[holdout["candidate"] == best].iloc[0]
     benchmark_row = holdout.loc[holdout["candidate"] == "buy_and_hold"].iloc[0]
     lead = (
-        f"The frozen {best} rule produced {_format_percent(strategy_row['cagr'])} annualized "
-        f"with {_format_percent(strategy_row['max_drawdown'])} maximum drawdown in the retrospective "
-        f"holdout, versus {_format_percent(benchmark_row['cagr'])} and "
-        f"{_format_percent(benchmark_row['max_drawdown'])} for buy-and-hold."
+        f"冻结后的{STRATEGY_LABELS_ZH[best]}策略，在回顾性留出期内年化收益率为"
+        f"{_format_percent(strategy_row['cagr'])}，最大回撤为"
+        f"{_format_percent(strategy_row['max_drawdown'])}；同期买入并持有的年化收益率为"
+        f"{_format_percent(benchmark_row['cagr'])}，最大回撤为"
+        f"{_format_percent(benchmark_row['max_drawdown'])}。"
     )
     escaped_manifest = html.escape(json.dumps(manifest, indent=2, default=str))
     return f"""<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Agricultural Bank of China breakout trend research</title>
+<html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>农业银行趋势交易研究</title>
 <style>
 :root{{--ink:#172033;--muted:#617087;--line:#dfe5ec;--brand:#405cf5;--good:#147d55;--bad:#bd3f3f}}
 *{{box-sizing:border-box}}body{{margin:0;background:#f5f7fa;color:var(--ink);font:15px/1.6 system-ui,sans-serif}}
@@ -435,26 +487,28 @@ th,td{{padding:8px;border-bottom:1px solid var(--line);text-align:right;white-sp
 .scroll-shell.overflows .scroll-hint{{display:block;background:#eef1ff;color:#3146b8;text-align:center;padding:6px 10px;border-radius:8px 8px 0 0;font-size:12px;font-weight:650}}
 .scroll-shell.overflows:not(.at-end)::after{{content:"";position:absolute;right:0;bottom:6px;width:34px;height:calc(100% - 32px);pointer-events:none;background:linear-gradient(90deg,transparent,rgba(89,104,216,.28))}}}}
 </style></head><body><main>
-<p class="pills"><span class="pill">601288.SS</span><span class="pill">long or cash</span><span class="pill">next-open execution</span></p>
-<h1>Agricultural Bank of China: buy strength, sell weakness</h1>
+<p class="pills"><span class="pill">601288.SS</span><span class="pill">只做多或空仓</span><span class="pill">下一交易日开盘执行</span></p>
+<h1>农业银行：突破后买入，趋势破坏后卖出</h1>
 <p class="lead">{html.escape(lead)}</p>
-<section><h2>Decision</h2><div class="grid">
-<div class="card">Frozen rule<b>{html.escape(best)}</b><span>selected before the holdout</span></div>
-<div class="card">Next action<b>{html.escape(latest['action'])}</b><span>target exposure {latest['target_exposure']:.0%}</span></div>
-<div class="card">Bootstrap resamples above zero<b>{bootstrap['probability_annual_return_diff_positive']:.1%}</b><span>fraction of paired block resamples with a positive mean-return difference</span></div>
-</div><p class="warning"><strong>Research only.</strong> The holdout is retrospective, not genuinely unseen future data. No broker connection or automatic order path exists.</p></section>
-<section><h2>Rule</h2><p>Enter after the completed close breaks above the prior N-session high; exit after it breaks below the prior M-session low. The order is modeled at the next adjusted open. This is the literal "chase strength and cut weakness" interpretation.</p>
-<ul><li>Long-only; no short selling or leverage.</li><li>Total-return adjusted prices include dividend effects while held.</li><li>Base friction: {config['buy_cost_bps']:g} bps on buys and {config['sell_cost_bps']:g} bps on sells.</li><li>Candidate selection used only dates through {config['selection_end']}.</li></ul></section>
-<section><h2>Buy / sell points and cumulative return</h2>
-<p>Green triangles are modeled next-open buys; red triangles are modeled next-open sells. The lower panel shows cumulative return after transaction costs.</p>
-<img class="chart" src="data:image/svg+xml;base64,{chart_data}" alt="Agricultural Bank adjusted price with buy and sell points, plus cumulative strategy and buy-and-hold returns">
+<section><h2>结论</h2><div class="grid">
+<div class="card">冻结策略<b>{html.escape(STRATEGY_LABELS_ZH[best])}</b><span>仅使用2022年及以前数据选定</span></div>
+<div class="card">当前动作<b>{html.escape(ACTION_LABELS_ZH[latest['action']])}</b><span>策略资金目标仓位 {latest['target_exposure']:.0%}</span></div>
+<div class="card">相对收益为正的重采样占比<b>{bootstrap['probability_annual_return_diff_positive']:.1%}</b><span>成对区块重采样中，策略平均收益差大于零的比例</span></div>
+</div><p class="warning"><strong>仅供研究。</strong> 2023年后的留出期已经被查看，因此属于回顾性检验，不是真正未见的未来数据；本研究不连接券商，也不会自动下单。</p></section>
+<section><h2>什么时候买，什么时候卖</h2>
+<p><strong>买入：</strong>当日收盘价突破此前{entry_window}个交易日的最高收盘价，收盘后确认信号；<strong>下一交易日开盘，按策略资金100%买入。</strong></p>
+<p><strong>卖出：</strong>持仓后，当日收盘价跌破此前{exit_window}个交易日的最低收盘价，收盘后确认信号；<strong>下一交易日开盘全部卖出。</strong></p>
+<ul><li>仓位只有两种：100%持有农业银行，或者0%空仓；不分批、不做空、不加杠杆。</li><li>使用总回报复权价格，持仓期间的分红影响计入收益。</li><li>基础交易成本：买入{config['buy_cost_bps']:g}个基点，卖出{config['sell_cost_bps']:g}个基点。</li><li>候选参数只使用截至{config['selection_end']}的数据选择，之后参数冻结。</li></ul></section>
+<section><h2>买卖点与累计收益率</h2>
+<p>绿色上三角表示下一交易日开盘买入，红色下三角表示下一交易日开盘卖出；图内规则框直接写明触发条件。下半图展示扣除交易成本后的累计收益率。</p>
+<img class="chart" src="data:image/svg+xml;base64,{chart_data}" alt="农业银行复权股价、买卖点，以及趋势策略与买入持有的累计收益率">
 <div class="scroll">{trade_view.to_html(index=False, border=0, escape=True)}</div></section>
-<section><h2>Retrospective holdout</h2><div class="scroll">{holdout_view.to_html(index=False, border=0, escape=True)}</div></section>
-<section><h2>Development candidates</h2><div class="scroll">{development_view.to_html(index=False, border=0, escape=True)}</div></section>
-<section><h2>Annual return path</h2><div class="scroll">{annual_view.to_html(index=False, border=0, escape=True)}</div></section>
-<section><h2>Uncertainty</h2><p>Annualized mean daily return difference from the paired moving-block bootstrap: {bootstrap['annual_return_diff']:.2%}; confidence interval {bootstrap['annual_return_diff_ci_low']:.2%} to {bootstrap['annual_return_diff_ci_high']:.2%}. This is not a CAGR difference or a posterior probability of an edge. An interval crossing zero means the historical difference is unresolved.</p></section>
-<section><h2>Failure conditions</h2><ul><li>Sideways markets can cause repeated false breakouts and small losses.</li><li>Gap-down opens can make the modeled exit materially worse than the signal close.</li><li>A single bank stock carries policy, credit-cycle, and company-specific concentration risk.</li><li>Stop using the rule if future paper results materially diverge from the recorded cost and execution assumptions.</li></ul></section>
-<section><h2>Provenance</h2><p>Run ID: <code>{html.escape(run_id)}</code></p><pre>{escaped_manifest}</pre></section>
+<section><h2>回顾性留出期</h2><div class="scroll">{holdout_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>开发期候选策略</h2><div class="scroll">{development_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>分年度收益率</h2><div class="scroll">{annual_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>不确定性</h2><p>成对移动区块自助法估计的“日均收益差年化值”为 {bootstrap['annual_return_diff']:.2%}，95%区间为 {bootstrap['annual_return_diff_ci_low']:.2%} 至 {bootstrap['annual_return_diff_ci_high']:.2%}。这不是年化复合收益率之差，也不是策略存在优势的后验概率；区间跨过零，说明历史相对收益差尚无定论。</p></section>
+<section><h2>策略可能失效的情况</h2><ul><li>横盘震荡会反复出现假突破，造成连续小亏。</li><li>跳空低开时，实际卖出价可能明显差于发出信号时的收盘价。</li><li>单押一只银行股，仍承担政策、信用周期和公司个体风险。</li><li>如果未来模拟结果持续偏离本报告的成本与成交假设，应停止使用该规则并重新评估。</li></ul></section>
+<section><h2>运行溯源</h2><p>运行编号：<code>{html.escape(run_id)}</code></p><p>以下为机器可读字段，字段名保留英文以便复现。</p><pre>{escaped_manifest}</pre></section>
 <script>(()=>{{
   const update=(shell,scroll)=>{{
     const overflow=scroll.scrollWidth>scroll.clientWidth+1;
@@ -468,7 +522,7 @@ th,td{{padding:8px;border-bottom:1px solid var(--line);text-align:right;white-sp
     scroll.parentNode.insertBefore(shell,scroll);
     const hint=document.createElement('div');
     hint.className='scroll-hint';
-    hint.textContent='← Swipe horizontally for the full table →';
+    hint.textContent='← 横向滑动查看完整表格 →';
     shell.append(hint,scroll);
     pairs.push([shell,scroll]);
     scroll.addEventListener('scroll',()=>update(shell,scroll),{{passive:true}});

--- a/projects/quant-research-platform/src/gold_research/abc.py
+++ b/projects/quant-research-platform/src/gold_research/abc.py
@@ -1,0 +1,704 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import io
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .backtest import backtest, metrics, trade_ledger
+from .round3 import completed_signal_close
+from .run import _data_hash, canonical_hash, get_git_state, stable_run_id
+from .strategies import buy_hold_signal, donchian_signal
+from .validation import paired_block_bootstrap
+
+ABC_CANDIDATES = [
+    "buy_and_hold",
+    "breakout_20_10",
+    "breakout_40_20",
+    "breakout_60_20",
+    "breakout_120_40",
+]
+ABC_PARAMETERS = {
+    "breakout_20_10": (20, 10),
+    "breakout_40_20": (40, 20),
+    "breakout_60_20": (60, 20),
+    "breakout_120_40": (120, 40),
+}
+ABC_SYMBOL = "601288.SS"
+ABC_HOLDOUT_START = pd.Timestamp("2023-01-01")
+
+
+def _session_index(index: pd.Index) -> pd.DatetimeIndex:
+    """Normalize daily bars while preserving their exchange-local calendar date."""
+    parsed = pd.DatetimeIndex(pd.to_datetime(index, errors="coerce"))
+    if parsed.isna().any():
+        raise ValueError("session dates must be valid and non-missing")
+    if parsed.tz is not None:
+        parsed = parsed.tz_localize(None)
+    return parsed.normalize()
+
+
+def _verify_source_artifact(frame: pd.DataFrame, manifest: dict, symbol: str) -> None:
+    required = {"symbol", "url", "csv", "csv_sha256", "rows", "data_start", "data_end"}
+    if not required <= manifest.keys():
+        raise ValueError("data manifest is missing required source artifact fields")
+    parsed_url = urlparse(str(manifest["url"]))
+    expected_path = f"/v8/finance/chart/{symbol}"
+    try:
+        valid_port = parsed_url.port in (None, 443)
+    except ValueError:
+        valid_port = False
+    if (
+        parsed_url.scheme != "https"
+        or parsed_url.hostname != "query1.finance.yahoo.com"
+        or not valid_port
+        or parsed_url.username is not None
+        or parsed_url.password is not None
+        or unquote(parsed_url.path) != expected_path
+        or parsed_url.fragment
+    ):
+        raise ValueError("source artifact URL does not identify the canonical Yahoo chart endpoint")
+    csv_path = Path(str(manifest["csv"]))
+    if not csv_path.is_file():
+        raise ValueError("source artifact CSV is missing")
+    csv_digest = hashlib.sha256(csv_path.read_bytes()).hexdigest()
+    if csv_digest != manifest["csv_sha256"]:
+        raise ValueError("source artifact CSV checksum does not match the manifest")
+    try:
+        source = pd.read_csv(csv_path, float_precision="round_trip")
+    except Exception as exc:
+        raise ValueError("source artifact CSV cannot be read") from exc
+    if "Date" not in source.columns:
+        raise ValueError("source artifact CSV is missing Date")
+    source = source.set_index("Date")
+    canonical = ["Open", "High", "Low", "Close", "Adj Close", "Volume"]
+    source_columns = [column for column in canonical if column in source.columns]
+    frame_columns = [column for column in canonical if column in frame.columns]
+    if source_columns != frame_columns:
+        raise ValueError("source artifact columns do not match the supplied frame")
+    source.index = _session_index(source.index)
+    candidate = frame.loc[:, frame_columns].copy()
+    candidate.index = _session_index(candidate.index)
+    source = source.loc[:, source_columns].sort_index()
+    candidate = candidate.sort_index()
+    try:
+        pd.testing.assert_frame_equal(
+            candidate,
+            source,
+            check_exact=True,
+            check_dtype=False,
+            check_names=False,
+        )
+    except AssertionError as exc:
+        raise ValueError("source artifact contents do not match the supplied frame") from exc
+    if int(manifest["rows"]) != len(source):
+        raise ValueError("source artifact row count does not match the manifest")
+    data_start = source.index.min().date().isoformat()
+    data_end = source.index.max().date().isoformat()
+    if manifest["data_start"] != data_start or manifest["data_end"] != data_end:
+        raise ValueError("source artifact date range does not match the manifest")
+
+
+def adjusted_ohlc(frame: pd.DataFrame) -> pd.DataFrame:
+    """Convert Yahoo OHLC rows to the same total-return scale as adjusted close."""
+    required = {"Open", "Close", "Adj Close"}
+    missing = required - set(frame)
+    if missing:
+        raise ValueError(f"missing required price columns: {', '.join(sorted(missing))}")
+    result = frame.copy()
+    price_columns = [column for column in ("Open", "High", "Low", "Close", "Adj Close") if column in result]
+    raw = result.loc[:, price_columns]
+    contains_boolean = raw.map(lambda value: isinstance(value, (bool, np.bool_))).any().any()
+    numeric = raw.apply(pd.to_numeric, errors="coerce")
+    if (
+        contains_boolean
+        or not np.isfinite(numeric.to_numpy(dtype=float)).all()
+        or (numeric <= 0.0).any().any()
+    ):
+        raise ValueError("prices must be finite and strictly positive")
+    factor = numeric["Adj Close"] / numeric["Close"]
+    for column in ("Open", "High", "Low"):
+        if column in numeric:
+            result[column] = numeric[column] * factor
+    result["Close"] = numeric["Adj Close"]
+    result["Adj Close"] = numeric["Adj Close"]
+    result.index = _session_index(result.index)
+    result = result.sort_index()
+    if result.index.has_duplicates:
+        raise ValueError("price data contains duplicate dates")
+    return result
+
+
+def abc_candidate_signals(close: pd.Series) -> dict[str, pd.Series]:
+    """Fixed long-or-cash breakout family: buy strength and sell weakness."""
+    signals = {"buy_and_hold": buy_hold_signal(close)}
+    for name, (entry, exit_) in ABC_PARAMETERS.items():
+        signals[name] = donchian_signal(close, entry, exit_)
+    return signals
+
+
+def select_frozen_candidate(summary: pd.DataFrame) -> tuple[str, pd.DataFrame]:
+    """Select one candidate by balanced historical rank, then lower turnover."""
+    required = {"candidate", "cagr", "sharpe", "calmar", "turnover"}
+    if not required <= set(summary):
+        raise ValueError("candidate summary is missing required selection metrics")
+    ranking = summary.copy()
+    for name in ("cagr", "sharpe", "calmar"):
+        ranking[f"{name}_rank"] = ranking[name].rank(method="average", ascending=False)
+    ranking["mean_metric_rank"] = ranking[
+        ["cagr_rank", "sharpe_rank", "calmar_rank"]
+    ].mean(axis=1)
+    ranking = ranking.sort_values(
+        ["mean_metric_rank", "turnover", "candidate"], kind="stable"
+    ).reset_index(drop=True)
+    return str(ranking.iloc[0]["candidate"]), ranking
+
+
+def _metric_row(candidate: str, result: pd.DataFrame) -> dict:
+    return {"candidate": candidate, **metrics(result)}
+
+
+def _annual_returns(results: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    rows = []
+    for candidate, result in results.items():
+        returns = result["net_return"].astype(float)
+        for year, values in returns.groupby(returns.index.year):
+            rows.append(
+                {
+                    "candidate": candidate,
+                    "year": int(year),
+                    "observations": int(len(values)),
+                    "total_return": float((1.0 + values).prod() - 1.0),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _trade_path(trades: pd.DataFrame, result: pd.DataFrame) -> pd.DataFrame:
+    """Attach strategy equity after every completed or marked-open trade."""
+    columns = [
+        "entry_date",
+        "entry_price",
+        "exit_date",
+        "exit_price",
+        "bars",
+        "trade_return",
+        "cumulative_return",
+        "is_open",
+    ]
+    if trades.empty:
+        return pd.DataFrame(columns=columns)
+    rows = []
+    for _, trade in trades.iterrows():
+        is_open = bool(trade["is_open"])
+        event_date = result.index[-1] if is_open else pd.Timestamp(trade["exit_date"])
+        rows.append(
+            {
+                "entry_date": pd.Timestamp(trade["entry_date"]),
+                "entry_price": float(trade["entry_price"]),
+                "exit_date": pd.NaT if is_open else event_date,
+                "exit_price": np.nan if is_open else float(trade["exit_price"]),
+                "bars": int(trade["bars"]),
+                "trade_return": float(trade["net_return"]),
+                "cumulative_return": float(result.loc[event_date, "equity_net"] - 1.0),
+                "is_open": is_open,
+            }
+        )
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _strategy_chart(
+    holdout: pd.DataFrame,
+    strategy_result: pd.DataFrame,
+    benchmark_result: pd.DataFrame,
+    trade_path: pd.DataFrame,
+    strategy_name: str,
+) -> str:
+    """Render adjusted price transitions and costed cumulative-return paths."""
+    with plt.rc_context({"svg.hashsalt": "abc-breakout-trend-v1"}):
+        figure, axes = plt.subplots(2, 1, figsize=(11, 7.5), sharex=True, constrained_layout=True)
+        price_axis, return_axis = axes
+        price_axis.plot(
+            holdout.index,
+            holdout["Close"],
+            color="#25364d",
+            linewidth=1.35,
+            label="Adjusted close",
+        )
+        if not trade_path.empty:
+            price_axis.scatter(
+                pd.to_datetime(trade_path["entry_date"]),
+                trade_path["entry_price"],
+                marker="^",
+                s=42,
+                color="#16855b",
+                edgecolors="white",
+                linewidths=0.6,
+                label="BUY",
+                zorder=3,
+            )
+            closed = trade_path.loc[~trade_path["is_open"].astype(bool)]
+            if not closed.empty:
+                price_axis.scatter(
+                    pd.to_datetime(closed["exit_date"]),
+                    closed["exit_price"],
+                    marker="v",
+                    s=42,
+                    color="#c93f3f",
+                    edgecolors="white",
+                    linewidths=0.6,
+                    label="SELL",
+                    zorder=3,
+                )
+        price_axis.set_title("Agricultural Bank adjusted price with modeled transitions")
+        price_axis.set_ylabel("Adjusted price (CNY)")
+        price_axis.grid(alpha=0.22)
+        price_axis.legend(loc="upper left", ncols=3, frameon=False)
+
+        strategy_curve = (strategy_result["equity_net"] - 1.0) * 100.0
+        benchmark_curve = (benchmark_result["equity_net"] - 1.0) * 100.0
+        return_axis.plot(
+            strategy_curve.index,
+            strategy_curve,
+            color="#405cf5",
+            linewidth=1.7,
+            label=f"{strategy_name} after costs",
+        )
+        return_axis.plot(
+            benchmark_curve.index,
+            benchmark_curve,
+            color="#8a94a6",
+            linewidth=1.25,
+            label="Buy-and-hold after costs",
+        )
+        return_axis.axhline(0.0, color="#98a2b3", linewidth=0.8)
+        return_axis.set_title("Cumulative return")
+        return_axis.set_ylabel("Return (%)")
+        return_axis.set_xlabel("Date")
+        return_axis.grid(alpha=0.22)
+        return_axis.legend(loc="upper left", frameon=False)
+        for curve, color in ((strategy_curve, "#405cf5"), (benchmark_curve, "#687386")):
+            return_axis.annotate(
+                f"{curve.iloc[-1]:+.1f}%",
+                xy=(curve.index[-1], curve.iloc[-1]),
+                xytext=(-4, 8),
+                textcoords="offset points",
+                ha="right",
+                color=color,
+                fontsize=9,
+                fontweight="bold",
+            )
+        buffer = io.StringIO()
+        figure.savefig(buffer, format="svg", metadata={"Date": None})
+        plt.close(figure)
+    return buffer.getvalue()
+
+
+def _latest_action(close: pd.Series, candidate: str) -> dict:
+    next_date = close.index[-1] + pd.offsets.BDay(1)
+    extended = pd.concat([close, pd.Series([close.iloc[-1]], index=[next_date])])
+    signal = abc_candidate_signals(extended)[candidate]
+    previous = float(signal.iloc[-2])
+    target = float(signal.iloc[-1])
+    if previous <= 0.0 < target:
+        action = "BUY"
+    elif previous > 0.0 >= target:
+        action = "SELL"
+    else:
+        action = "HOLD" if target > 0.0 else "CASH"
+    return {
+        "candidate": candidate,
+        "signal_as_of_date": close.index[-1].date().isoformat(),
+        "next_model_date": next_date.date().isoformat(),
+        "previous_exposure": previous,
+        "target_exposure": target,
+        "action": action,
+    }
+
+
+def _format_percent(value: float) -> str:
+    return f"{value:.1%}"
+
+
+def _render_report(
+    run_id: str,
+    config: dict,
+    manifest: dict,
+    development: pd.DataFrame,
+    holdout: pd.DataFrame,
+    annual: pd.DataFrame,
+    bootstrap: dict,
+    latest: dict,
+    trade_path: pd.DataFrame,
+    chart_svg: str,
+) -> str:
+    best = config["best_frozen_candidate"]
+    holdout_view = holdout.loc[
+        :, ["candidate", "cumulative_return", "cagr", "max_drawdown", "sharpe", "calmar"]
+    ].copy()
+    for column in ("cumulative_return", "cagr", "max_drawdown"):
+        holdout_view[column] = holdout_view[column].map(_format_percent)
+    for column in ("sharpe", "calmar"):
+        holdout_view[column] = holdout_view[column].map(lambda value: f"{value:.2f}")
+    holdout_view = holdout_view.rename(
+        columns={
+            "candidate": "Strategy",
+            "cumulative_return": "Cumulative return",
+            "cagr": "CAGR",
+            "max_drawdown": "Maximum drawdown",
+            "sharpe": "Sharpe",
+            "calmar": "Calmar",
+        }
+    )
+    development_view = development.loc[
+        :, ["candidate", "cagr", "max_drawdown", "sharpe", "calmar", "turnover"]
+    ].copy()
+    for column in ("cagr", "max_drawdown"):
+        development_view[column] = development_view[column].map(_format_percent)
+    for column in ("sharpe", "calmar", "turnover"):
+        development_view[column] = development_view[column].map(lambda value: f"{value:.2f}")
+    development_view = development_view.rename(
+        columns={
+            "candidate": "Strategy",
+            "cagr": "CAGR",
+            "max_drawdown": "Maximum drawdown",
+            "sharpe": "Sharpe",
+            "calmar": "Calmar",
+            "turnover": "Turnover",
+        }
+    )
+    annual_view = annual.pivot(index="year", columns="candidate", values="total_return").reset_index()
+    for column in annual_view.columns[1:]:
+        annual_view[column] = annual_view[column].map(_format_percent)
+    trade_view = trade_path.loc[
+        :, ["entry_date", "entry_price", "exit_date", "exit_price", "trade_return", "cumulative_return"]
+    ].copy()
+    trade_view["entry_date"] = pd.to_datetime(trade_view["entry_date"]).dt.date.astype(str)
+    trade_view["exit_date"] = pd.to_datetime(trade_view["exit_date"]).dt.date.astype("string").fillna("OPEN")
+    for column in ("entry_price", "exit_price"):
+        trade_view[column] = trade_view[column].map(
+            lambda value: "—" if pd.isna(value) else f"{float(value):.3f}"
+        )
+    for column in ("trade_return", "cumulative_return"):
+        trade_view[column] = trade_view[column].map(_format_percent)
+    trade_view = trade_view.rename(
+        columns={
+            "entry_date": "Buy date",
+            "entry_price": "Buy price",
+            "exit_date": "Sell date",
+            "exit_price": "Sell price",
+            "trade_return": "Trade return",
+            "cumulative_return": "Cumulative return",
+        }
+    )
+    chart_data = base64.b64encode(chart_svg.encode()).decode()
+    strategy_row = holdout.loc[holdout["candidate"] == best].iloc[0]
+    benchmark_row = holdout.loc[holdout["candidate"] == "buy_and_hold"].iloc[0]
+    lead = (
+        f"The frozen {best} rule produced {_format_percent(strategy_row['cagr'])} annualized "
+        f"with {_format_percent(strategy_row['max_drawdown'])} maximum drawdown in the retrospective "
+        f"holdout, versus {_format_percent(benchmark_row['cagr'])} and "
+        f"{_format_percent(benchmark_row['max_drawdown'])} for buy-and-hold."
+    )
+    escaped_manifest = html.escape(json.dumps(manifest, indent=2, default=str))
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Agricultural Bank of China breakout trend research</title>
+<style>
+:root{{--ink:#172033;--muted:#617087;--line:#dfe5ec;--brand:#405cf5;--good:#147d55;--bad:#bd3f3f}}
+*{{box-sizing:border-box}}body{{margin:0;background:#f5f7fa;color:var(--ink);font:15px/1.6 system-ui,sans-serif}}
+main{{max-width:1080px;margin:auto;padding:24px}}section{{background:white;border:1px solid var(--line);border-radius:14px;padding:20px;margin:16px 0}}
+h1{{font-size:clamp(28px,5vw,48px);line-height:1.08;margin:.2em 0}}h2{{margin-top:0}}.lead{{font-size:18px;color:#344158}}
+.pills{{display:flex;gap:8px;flex-wrap:wrap}}.pill{{background:#eef1ff;color:#3146b8;padding:4px 10px;border-radius:999px}}
+.grid{{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}}.card{{border:1px solid var(--line);border-radius:10px;padding:14px}}
+.card b{{display:block;font-size:24px}}.scroll-shell{{position:relative}}.scroll{{overflow-x:auto;scrollbar-width:thin;scrollbar-color:#5968d8 #e8ebf5}}
+.scroll::-webkit-scrollbar{{height:6px;-webkit-appearance:none}}.scroll::-webkit-scrollbar-track{{background:#e8ebf5}}.scroll::-webkit-scrollbar-thumb{{background:#5968d8;border-radius:999px}}.scroll-hint{{display:none}}
+table{{border-collapse:collapse;width:100%;font-size:13px}}
+.chart{{display:block;width:100%;height:auto;border:1px solid var(--line);border-radius:10px;background:white}}
+th,td{{padding:8px;border-bottom:1px solid var(--line);text-align:right;white-space:nowrap}}th:first-child,td:first-child{{text-align:left}}
+.warning{{border-left:4px solid #d68a00;background:#fff8e8;padding:12px}}pre{{white-space:pre-wrap;overflow-wrap:anywhere;font-size:12px;background:#f7f8fa;padding:12px;border-radius:8px}}
+@media(max-width:640px){{main{{padding:12px}}section{{padding:14px}}.grid{{grid-template-columns:1fr}}
+.scroll-shell.overflows .scroll-hint{{display:block;background:#eef1ff;color:#3146b8;text-align:center;padding:6px 10px;border-radius:8px 8px 0 0;font-size:12px;font-weight:650}}
+.scroll-shell.overflows:not(.at-end)::after{{content:"";position:absolute;right:0;bottom:6px;width:34px;height:calc(100% - 32px);pointer-events:none;background:linear-gradient(90deg,transparent,rgba(89,104,216,.28))}}}}
+</style></head><body><main>
+<p class="pills"><span class="pill">601288.SS</span><span class="pill">long or cash</span><span class="pill">next-open execution</span></p>
+<h1>Agricultural Bank of China: buy strength, sell weakness</h1>
+<p class="lead">{html.escape(lead)}</p>
+<section><h2>Decision</h2><div class="grid">
+<div class="card">Frozen rule<b>{html.escape(best)}</b><span>selected before the holdout</span></div>
+<div class="card">Next action<b>{html.escape(latest['action'])}</b><span>target exposure {latest['target_exposure']:.0%}</span></div>
+<div class="card">Bootstrap resamples above zero<b>{bootstrap['probability_annual_return_diff_positive']:.1%}</b><span>fraction of paired block resamples with a positive mean-return difference</span></div>
+</div><p class="warning"><strong>Research only.</strong> The holdout is retrospective, not genuinely unseen future data. No broker connection or automatic order path exists.</p></section>
+<section><h2>Rule</h2><p>Enter after the completed close breaks above the prior N-session high; exit after it breaks below the prior M-session low. The order is modeled at the next adjusted open. This is the literal "chase strength and cut weakness" interpretation.</p>
+<ul><li>Long-only; no short selling or leverage.</li><li>Total-return adjusted prices include dividend effects while held.</li><li>Base friction: {config['buy_cost_bps']:g} bps on buys and {config['sell_cost_bps']:g} bps on sells.</li><li>Candidate selection used only dates through {config['selection_end']}.</li></ul></section>
+<section><h2>Buy / sell points and cumulative return</h2>
+<p>Green triangles are modeled next-open buys; red triangles are modeled next-open sells. The lower panel shows cumulative return after transaction costs.</p>
+<img class="chart" src="data:image/svg+xml;base64,{chart_data}" alt="Agricultural Bank adjusted price with buy and sell points, plus cumulative strategy and buy-and-hold returns">
+<div class="scroll">{trade_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>Retrospective holdout</h2><div class="scroll">{holdout_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>Development candidates</h2><div class="scroll">{development_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>Annual return path</h2><div class="scroll">{annual_view.to_html(index=False, border=0, escape=True)}</div></section>
+<section><h2>Uncertainty</h2><p>Annualized mean daily return difference from the paired moving-block bootstrap: {bootstrap['annual_return_diff']:.2%}; confidence interval {bootstrap['annual_return_diff_ci_low']:.2%} to {bootstrap['annual_return_diff_ci_high']:.2%}. This is not a CAGR difference or a posterior probability of an edge. An interval crossing zero means the historical difference is unresolved.</p></section>
+<section><h2>Failure conditions</h2><ul><li>Sideways markets can cause repeated false breakouts and small losses.</li><li>Gap-down opens can make the modeled exit materially worse than the signal close.</li><li>A single bank stock carries policy, credit-cycle, and company-specific concentration risk.</li><li>Stop using the rule if future paper results materially diverge from the recorded cost and execution assumptions.</li></ul></section>
+<section><h2>Provenance</h2><p>Run ID: <code>{html.escape(run_id)}</code></p><pre>{escaped_manifest}</pre></section>
+<script>(()=>{{
+  const update=(shell,scroll)=>{{
+    const overflow=scroll.scrollWidth>scroll.clientWidth+1;
+    shell.classList.toggle('overflows',overflow);
+    shell.classList.toggle('at-end',!overflow||scroll.scrollLeft+scroll.clientWidth>=scroll.scrollWidth-2);
+  }};
+  const pairs=[];
+  document.querySelectorAll('.scroll').forEach(scroll=>{{
+    const shell=document.createElement('div');
+    shell.className='scroll-shell';
+    scroll.parentNode.insertBefore(shell,scroll);
+    const hint=document.createElement('div');
+    hint.className='scroll-hint';
+    hint.textContent='← Swipe horizontally for the full table →';
+    shell.append(hint,scroll);
+    pairs.push([shell,scroll]);
+    scroll.addEventListener('scroll',()=>update(shell,scroll),{{passive:true}});
+  }});
+  const refreshAll=()=>pairs.forEach(([shell,scroll])=>update(shell,scroll));
+  requestAnimationFrame(refreshAll);
+  window.addEventListener('load', refreshAll);
+  window.addEventListener('resize', refreshAll,{{passive:true}});
+}})();</script>
+</main></body></html>"""
+
+
+def run_abc_trend_research(
+    frame: pd.DataFrame,
+    output_root: Path,
+    *,
+    symbol: str,
+    data_manifest: dict,
+    holdout_start: pd.Timestamp | str = "2023-01-01",
+    analysis_date: pd.Timestamp | datetime | None = None,
+    buy_cost_bps: float = 8.0,
+    sell_cost_bps: float = 13.0,
+    stress_buy_cost_bps: float = 20.0,
+    stress_sell_cost_bps: float = 25.0,
+    bootstrap_samples: int = 10_000,
+) -> dict:
+    """Run the canonical frozen breakout-family study for Agricultural Bank."""
+    if symbol != ABC_SYMBOL:
+        raise ValueError(f"this study only accepts {ABC_SYMBOL}")
+    if not isinstance(data_manifest, dict) or data_manifest.get("symbol") != symbol:
+        raise ValueError("data manifest must identify the verified 601288.SS input")
+    _verify_source_artifact(frame, data_manifest, symbol)
+    frame_symbol = frame.attrs.get("symbol")
+    if frame_symbol is not None and frame_symbol != symbol:
+        raise ValueError("frame symbol conflicts with the verified data manifest")
+    adjusted = adjusted_ohlc(frame)
+    analysis_date = analysis_date or datetime.now(timezone.utc)
+    completed_close, excluded_partial = completed_signal_close(
+        adjusted["Close"],
+        analysis_date,
+        exchange_timezone="Asia/Shanghai",
+    )
+    adjusted = adjusted.reindex(completed_close.index)
+    if len(adjusted) < 500:
+        raise ValueError("at least 500 completed sessions are required")
+    holdout_start = pd.Timestamp(holdout_start).tz_localize(None).normalize()
+    if holdout_start != ABC_HOLDOUT_START:
+        raise ValueError("canonical Agricultural Bank study holdout must start on 2023-01-01")
+    development = adjusted.loc[adjusted.index < holdout_start]
+    holdout = adjusted.loc[adjusted.index >= holdout_start]
+    development_warmup_sessions = max(entry for entry, _ in ABC_PARAMETERS.values())
+    if len(development) < development_warmup_sessions + 252 or len(holdout) < 252:
+        raise ValueError("development and holdout periods each require enough evaluated sessions")
+    development_evaluation = development.iloc[development_warmup_sessions:]
+    if any(
+        isinstance(value, (bool, np.bool_))
+        or not np.isfinite(float(value))
+        or float(value) < 0.0
+        for value in (buy_cost_bps, sell_cost_bps, stress_buy_cost_bps, stress_sell_cost_bps)
+    ):
+        raise ValueError("cost values must be finite and non-negative")
+    if bootstrap_samples < 1:
+        raise ValueError("bootstrap_samples must be positive")
+
+    config = {
+        "version": 1,
+        "symbol": symbol,
+        "candidate_names": ABC_CANDIDATES,
+        "holdout_start": holdout_start.date().isoformat(),
+        "selection_end": development.index[-1].date().isoformat(),
+        "development_warmup_sessions": development_warmup_sessions,
+        "development_evaluation_start": development_evaluation.index[0].date().isoformat(),
+        "analysis_date": pd.Timestamp(analysis_date).date().isoformat(),
+        "latest_completed_bar": adjusted.index[-1].date().isoformat(),
+        "excluded_partial_bar": bool(excluded_partial),
+        "execution": "completed close signal; next-session adjusted open fill",
+        "price_basis": "Yahoo adjusted-close factor applied to OHLC; total-return scale",
+        "cash_return": "zero",
+        "buy_cost_bps": float(buy_cost_bps),
+        "sell_cost_bps": float(sell_cost_bps),
+        "stress_buy_cost_bps": float(stress_buy_cost_bps),
+        "stress_sell_cost_bps": float(stress_sell_cost_bps),
+        "bootstrap_samples": int(bootstrap_samples),
+        "bootstrap_block_size": 20,
+        "selection_metrics": ["cagr", "sharpe", "calmar"],
+    }
+
+    all_signals = abc_candidate_signals(adjusted["Close"])
+    development_summary_rows = []
+    for candidate in ABC_CANDIDATES:
+        result = backtest(
+            development_evaluation["Open"],
+            all_signals[candidate].reindex(development_evaluation.index),
+            buy_cost_bps=buy_cost_bps,
+            sell_cost_bps=sell_cost_bps,
+        )
+        development_summary_rows.append(_metric_row(candidate, result))
+    development_summary = pd.DataFrame(development_summary_rows)
+    selectable = development_summary[development_summary["candidate"] != "buy_and_hold"].copy()
+    best, ranking = select_frozen_candidate(selectable)
+    config["best_frozen_candidate"] = best
+    config["selection_ranking"] = ranking[
+        ["candidate", "mean_metric_rank", "turnover"]
+    ].to_dict(orient="records")
+
+    holdout_results = {}
+    for candidate in ("buy_and_hold", best):
+        holdout_results[candidate] = backtest(
+            holdout["Open"],
+            all_signals[candidate].reindex(holdout.index),
+            buy_cost_bps=buy_cost_bps,
+            sell_cost_bps=sell_cost_bps,
+        )
+    holdout_summary = pd.DataFrame(
+        [_metric_row(candidate, result) for candidate, result in holdout_results.items()]
+    )
+
+    cost_rows = []
+    for label, buy_cost, sell_cost in (
+        ("base", buy_cost_bps, sell_cost_bps),
+        ("stress", stress_buy_cost_bps, stress_sell_cost_bps),
+    ):
+        for candidate in ("buy_and_hold", best):
+            result = backtest(
+                holdout["Open"],
+                all_signals[candidate].reindex(holdout.index),
+                buy_cost_bps=buy_cost,
+                sell_cost_bps=sell_cost,
+            )
+            cost_rows.append(
+                {
+                    "scenario": label,
+                    "buy_cost_bps": buy_cost,
+                    "sell_cost_bps": sell_cost,
+                    **_metric_row(candidate, result),
+                }
+            )
+    cost_stress = pd.DataFrame(cost_rows)
+    annual = _annual_returns(holdout_results)
+    bootstrap = {
+        "strategy": best,
+        "benchmark": "buy_and_hold",
+        **paired_block_bootstrap(
+            holdout_results[best]["net_return"],
+            holdout_results["buy_and_hold"]["net_return"],
+            samples=bootstrap_samples,
+            block_size=20,
+            seed=20260820,
+        ),
+    }
+    latest = _latest_action(adjusted["Close"], best)
+
+    daily_frames = []
+    trade_frames = []
+    for candidate, result in holdout_results.items():
+        daily = result.reset_index(names="date")
+        daily.insert(0, "candidate", candidate)
+        daily_frames.append(daily)
+        trades = trade_ledger(result)
+        if not trades.empty:
+            trades.insert(0, "candidate", candidate)
+            trade_frames.append(trades)
+    daily_returns = pd.concat(daily_frames, ignore_index=True)
+    trades = pd.concat(trade_frames, ignore_index=True) if trade_frames else pd.DataFrame(
+        columns=["candidate", "entry_date", "entry_price", "exit_date", "exit_price", "bars", "net_return", "is_open"]
+    )
+    strategy_ledger = trade_ledger(holdout_results[best])
+    trade_path = _trade_path(strategy_ledger, holdout_results[best])
+    chart_svg = _strategy_chart(
+        holdout,
+        holdout_results[best],
+        holdout_results["buy_and_hold"],
+        trade_path,
+        best,
+    )
+
+    hash_frame = frame.copy()
+    hash_frame.index = _session_index(hash_frame.index)
+    hash_frame = hash_frame.sort_index().reindex(adjusted.index)
+    data_hash = _data_hash({symbol: hash_frame})
+    project_root = Path(__file__).resolve().parents[2]
+    git = get_git_state(project_root)
+    run_id = stable_run_id(config, data_hash, canonical_hash(git))
+    output_root = Path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+    run_dir = output_root / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"immutable run already exists: {run_dir}")
+    manifest = {
+        "run_id": run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "data_hash": data_hash,
+        "git": git,
+        "data_manifest": data_manifest,
+    }
+    report = _render_report(
+        run_id,
+        config,
+        manifest,
+        development_summary,
+        holdout_summary,
+        annual,
+        bootstrap,
+        latest,
+        trade_path,
+        chart_svg,
+    )
+
+    temporary = Path(tempfile.mkdtemp(prefix=f".{run_id}-", dir=output_root))
+    try:
+        (temporary / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+        (temporary / "run_manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True, default=str) + "\n"
+        )
+        development_summary.to_csv(temporary / "development_summary.csv", index=False)
+        holdout_summary.to_csv(temporary / "holdout_summary.csv", index=False)
+        cost_stress.to_csv(temporary / "cost_stress_summary.csv", index=False)
+        annual.to_csv(temporary / "annual_returns.csv", index=False)
+        (temporary / "bootstrap.json").write_text(json.dumps(bootstrap, indent=2) + "\n")
+        daily_returns.to_csv(temporary / "daily_returns.csv", index=False)
+        trades.to_csv(temporary / "trades.csv", index=False)
+        trade_path.to_csv(temporary / "trade_path.csv", index=False)
+        (temporary / "strategy_chart.svg").write_text(chart_svg)
+        (temporary / "latest_signal.json").write_text(json.dumps(latest, indent=2) + "\n")
+        (temporary / "report.html").write_text(report)
+        for path in temporary.iterdir():
+            path.chmod(0o644)
+        temporary.chmod(0o755)
+        os.replace(temporary, run_dir)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return {"run_id": run_id, "run_dir": str(run_dir), "config": config}

--- a/projects/quant-research-platform/src/gold_research/abc_round2.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2.py
@@ -19,6 +19,8 @@ def _validated_frame(frame: pd.DataFrame) -> pd.DataFrame:
     if missing:
         raise ValueError(f"missing required OHLC columns: {', '.join(sorted(missing))}")
     _validate_index(frame.index)
+    if frame.empty:
+        raise ValueError("OHLC frame must not be empty")
     values = frame.loc[:, required]
     contains_boolean = values.map(lambda value: isinstance(value, (bool, np.bool_))).any().any()
     numeric = values.apply(pd.to_numeric, errors="coerce")
@@ -28,13 +30,20 @@ def _validated_frame(frame: pd.DataFrame) -> pd.DataFrame:
         or (numeric <= 0.0).any().any()
     ):
         raise ValueError("OHLC prices must be finite and strictly positive")
-    return numeric.astype(float)
+    numeric = numeric.astype(float)
+    if (numeric["High"] < numeric["Low"]).any():
+        raise ValueError("OHLC High must be greater than or equal to Low")
+    if ((numeric["Close"] < numeric["Low"]) | (numeric["Close"] > numeric["High"])).any():
+        raise ValueError("OHLC Close must be within the High-Low range")
+    return numeric
 
 
 def _validated_close(close: pd.Series) -> pd.Series:
     if not isinstance(close, pd.Series):
         raise ValueError("close must be a pandas Series")
     _validate_index(close.index)
+    if close.empty:
+        raise ValueError("close series must not be empty")
     contains_boolean = close.map(lambda value: isinstance(value, (bool, np.bool_))).any()
     numeric = pd.to_numeric(close, errors="coerce")
     if (
@@ -90,17 +99,22 @@ def mom_12m_monthly_signal(close: pd.Series) -> pd.Series:
     """Return exposure updated at each first session from the prior month-end close."""
     prices = _validated_close(close)
     exposure = pd.Series(0.0, index=prices.index, name="mom_12m_monthly")
-    month_ends: list[float] = []
+    month_ends: dict[pd.Period, float] = {}
     current = 0.0
     periods = prices.index.to_period("M")
     for position in range(1, len(prices)):
         if periods[position] != periods[position - 1]:
-            month_ends.append(float(prices.iloc[position - 1]))
-            if len(month_ends) >= 13:
-                if month_ends[-1] > month_ends[-13]:
+            completed_month = periods[position - 1]
+            comparison_month = completed_month - 12
+            month_ends[completed_month] = float(prices.iloc[position - 1])
+            scored_months = pd.period_range(comparison_month, completed_month, freq="M")
+            if all(month in month_ends for month in scored_months):
+                if month_ends[completed_month] > month_ends[comparison_month]:
                     current = 1.0
-                elif month_ends[-1] < month_ends[-13]:
+                elif month_ends[completed_month] < month_ends[comparison_month]:
                     current = 0.0
+            else:
+                current = 0.0
         exposure.iloc[position] = current
     return exposure
 
@@ -130,9 +144,12 @@ def _dmi_adx_14(frame: pd.DataFrame) -> pd.DataFrame:
     smooth_plus = np.full(size, np.nan)
     smooth_minus = np.full(size, np.nan)
     if size > period:
-        smooth_tr[period] = tr[1 : period + 1].sum()
-        smooth_plus[period] = plus_dm[1 : period + 1].sum()
-        smooth_minus[period] = minus_dm[1 : period + 1].sum()
+        seed_tr = tr[1:period].sum()
+        seed_plus = plus_dm[1:period].sum()
+        seed_minus = minus_dm[1:period].sum()
+        smooth_tr[period] = seed_tr - seed_tr / period + tr[period]
+        smooth_plus[period] = seed_plus - seed_plus / period + plus_dm[period]
+        smooth_minus[period] = seed_minus - seed_minus / period + minus_dm[period]
         for position in range(period + 1, size):
             smooth_tr[position] = (
                 smooth_tr[position - 1] - smooth_tr[position - 1] / period + tr[position]
@@ -238,7 +255,11 @@ def _turtle_n_20(prices: pd.DataFrame) -> pd.Series:
 
 
 def turtle_n_entry_weight(frame: pd.DataFrame, binary_signal: pd.Series) -> pd.Series:
-    """Size next-open entries using prior-close Turtle N and freeze each holding weight."""
+    """Freeze signal-close risk sizing for each next-open holding segment.
+
+    The frozen candidate formula is ``min(1, 0.01 * C_t / N_t)`` at the signal close.
+    An opening gap can therefore make exact realized next-open risk differ from this weight.
+    """
     prices = _validated_frame(frame)
     if not isinstance(binary_signal, pd.Series) or not binary_signal.index.equals(prices.index):
         raise ValueError("binary signal index must exactly match the OHLC frame")

--- a/projects/quant-research-platform/src/gold_research/abc_round2.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _validate_index(index: pd.Index) -> None:
+    if not isinstance(index, pd.DatetimeIndex) or index.hasnans:
+        raise ValueError("dates must be a valid DatetimeIndex")
+    if index.has_duplicates:
+        raise ValueError("dates must not contain duplicates")
+    if not index.is_monotonic_increasing:
+        raise ValueError("dates must be strictly increasing")
+
+
+def _validated_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    required = ["High", "Low", "Close"]
+    missing = set(required) - set(frame.columns)
+    if missing:
+        raise ValueError(f"missing required OHLC columns: {', '.join(sorted(missing))}")
+    _validate_index(frame.index)
+    values = frame.loc[:, required]
+    contains_boolean = values.map(lambda value: isinstance(value, (bool, np.bool_))).any().any()
+    numeric = values.apply(pd.to_numeric, errors="coerce")
+    if (
+        contains_boolean
+        or not np.isfinite(numeric.to_numpy(dtype=float)).all()
+        or (numeric <= 0.0).any().any()
+    ):
+        raise ValueError("OHLC prices must be finite and strictly positive")
+    return numeric.astype(float)
+
+
+def _validated_close(close: pd.Series) -> pd.Series:
+    if not isinstance(close, pd.Series):
+        raise ValueError("close must be a pandas Series")
+    _validate_index(close.index)
+    contains_boolean = close.map(lambda value: isinstance(value, (bool, np.bool_))).any()
+    numeric = pd.to_numeric(close, errors="coerce")
+    if (
+        contains_boolean
+        or not np.isfinite(numeric.to_numpy(dtype=float)).all()
+        or (numeric <= 0.0).any()
+    ):
+        raise ValueError("close prices must be finite and strictly positive")
+    return numeric.astype(float)
+
+
+def _next_open_exposure(state: pd.Series, name: str) -> pd.Series:
+    return state.shift(1, fill_value=0.0).astype(float).rename(name)
+
+
+def d55_20_close_signal(frame: pd.DataFrame) -> pd.Series:
+    """Return next-open exposure for the frozen 55/20 close-confirmed Donchian rule."""
+    prices = _validated_frame(frame)
+    upper = prices["High"].shift(1).rolling(55, min_periods=55).max()
+    lower = prices["Low"].shift(1).rolling(20, min_periods=20).min()
+    state = pd.Series(0.0, index=prices.index)
+    current = 0.0
+    for position in range(len(prices)):
+        close = prices["Close"].iloc[position]
+        if current == 0.0 and pd.notna(upper.iloc[position]) and close > upper.iloc[position]:
+            current = 1.0
+        elif current == 1.0 and pd.notna(lower.iloc[position]) and close < lower.iloc[position]:
+            current = 0.0
+        state.iloc[position] = current
+    return _next_open_exposure(state, "d55_20_close")
+
+
+def ma_hys_1_200_b1_signal(close: pd.Series) -> pd.Series:
+    """Return next-open exposure for the frozen 1/200 moving-average hysteresis rule."""
+    prices = _validated_close(close)
+    average = prices.rolling(200, min_periods=200).mean()
+    state = pd.Series(0.0, index=prices.index)
+    current = 0.0
+    for position in range(len(prices)):
+        if pd.isna(average.iloc[position]):
+            state.iloc[position] = current
+            continue
+        price = prices.iloc[position]
+        if current == 0.0 and price > 1.01 * average.iloc[position]:
+            current = 1.0
+        elif current == 1.0 and price < 0.99 * average.iloc[position]:
+            current = 0.0
+        state.iloc[position] = current
+    return _next_open_exposure(state, "ma_hys_1_200_b1")
+
+
+def mom_12m_monthly_signal(close: pd.Series) -> pd.Series:
+    """Return exposure updated at each first session from the prior month-end close."""
+    prices = _validated_close(close)
+    exposure = pd.Series(0.0, index=prices.index, name="mom_12m_monthly")
+    month_ends: list[float] = []
+    current = 0.0
+    periods = prices.index.to_period("M")
+    for position in range(1, len(prices)):
+        if periods[position] != periods[position - 1]:
+            month_ends.append(float(prices.iloc[position - 1]))
+            if len(month_ends) >= 13:
+                if month_ends[-1] > month_ends[-13]:
+                    current = 1.0
+                elif month_ends[-1] < month_ends[-13]:
+                    current = 0.0
+        exposure.iloc[position] = current
+    return exposure
+
+
+def _dmi_adx_14(frame: pd.DataFrame) -> pd.DataFrame:
+    prices = _validated_frame(frame)
+    period = 14
+    size = len(prices)
+    high = prices["High"].to_numpy()
+    low = prices["Low"].to_numpy()
+    close = prices["Close"].to_numpy()
+    tr = np.full(size, np.nan)
+    plus_dm = np.full(size, np.nan)
+    minus_dm = np.full(size, np.nan)
+    for position in range(1, size):
+        tr[position] = max(
+            high[position] - low[position],
+            abs(high[position] - close[position - 1]),
+            abs(low[position] - close[position - 1]),
+        )
+        up = high[position] - high[position - 1]
+        down = low[position - 1] - low[position]
+        plus_dm[position] = up if up > down and up > 0.0 else 0.0
+        minus_dm[position] = down if down > up and down > 0.0 else 0.0
+
+    smooth_tr = np.full(size, np.nan)
+    smooth_plus = np.full(size, np.nan)
+    smooth_minus = np.full(size, np.nan)
+    if size > period:
+        smooth_tr[period] = tr[1 : period + 1].sum()
+        smooth_plus[period] = plus_dm[1 : period + 1].sum()
+        smooth_minus[period] = minus_dm[1 : period + 1].sum()
+        for position in range(period + 1, size):
+            smooth_tr[position] = (
+                smooth_tr[position - 1] - smooth_tr[position - 1] / period + tr[position]
+            )
+            smooth_plus[position] = (
+                smooth_plus[position - 1] - smooth_plus[position - 1] / period + plus_dm[position]
+            )
+            smooth_minus[position] = (
+                smooth_minus[position - 1]
+                - smooth_minus[position - 1] / period
+                + minus_dm[position]
+            )
+        if (smooth_tr[period:] <= 0.0).any():
+            raise ValueError("DMI true-range denominator must be positive")
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        plus_di = 100.0 * smooth_plus / smooth_tr
+        minus_di = 100.0 * smooth_minus / smooth_tr
+        direction_total = plus_di + minus_di
+        dx = 100.0 * np.abs(plus_di - minus_di) / direction_total
+    if size > period and (
+        (direction_total[period:] <= 0.0).any() or not np.isfinite(dx[period:]).all()
+    ):
+        raise ValueError("DMI directional denominator must be positive")
+
+    adx = np.full(size, np.nan)
+    first_adx = 2 * period - 1
+    if size > first_adx:
+        adx[first_adx] = dx[period : first_adx + 1].mean()
+        for position in range(first_adx + 1, size):
+            adx[position] = ((period - 1) * adx[position - 1] + dx[position]) / period
+    return pd.DataFrame({"+DI": plus_di, "-DI": minus_di, "DX": dx, "ADX": adx}, index=prices.index)
+
+
+def _dmi_state(plus_di: pd.Series, minus_di: pd.Series, adx: pd.Series) -> pd.Series:
+    state = pd.Series(0.0, index=adx.index)
+    current = 0.0
+    for position in range(len(adx)):
+        if pd.isna(adx.iloc[position]):
+            state.iloc[position] = current
+            continue
+        if (
+            current == 0.0
+            and plus_di.iloc[position] > minus_di.iloc[position]
+            and adx.iloc[position] > 25.0
+        ):
+            current = 1.0
+        elif current == 1.0 and (
+            plus_di.iloc[position] <= minus_di.iloc[position] or adx.iloc[position] < 20.0
+        ):
+            current = 0.0
+        state.iloc[position] = current
+    return state
+
+
+def dmi_adx_14_25_20_signal(frame: pd.DataFrame) -> pd.Series:
+    """Return next-open exposure for the frozen Wilder DMI/ADX rule."""
+    indicators = _dmi_adx_14(frame)
+    state = _dmi_state(indicators["+DI"], indicators["-DI"], indicators["ADX"])
+    return _next_open_exposure(state, "dmi_adx_14_25_20")
+
+
+def core50_old20_10_signal(frame: pd.DataFrame) -> pd.Series:
+    """Return the diagnostic 50% core plus old 20/10 overlay next-open weight."""
+    prices = _validated_frame(frame)
+    upper = prices["High"].shift(1).rolling(20, min_periods=20).max()
+    lower = prices["Low"].shift(1).rolling(10, min_periods=10).min()
+    state = pd.Series(0.0, index=prices.index)
+    current = 0.0
+    for position in range(len(prices)):
+        close = prices["Close"].iloc[position]
+        if current == 0.0 and pd.notna(upper.iloc[position]) and close > upper.iloc[position]:
+            current = 1.0
+        elif current == 1.0 and pd.notna(lower.iloc[position]) and close < lower.iloc[position]:
+            current = 0.0
+        state.iloc[position] = current
+    exposure = _next_open_exposure(state, "core50_old20_10")
+    return 0.5 + 0.5 * exposure
+
+
+def _turtle_n_20(prices: pd.DataFrame) -> pd.Series:
+    size = len(prices)
+    high = prices["High"].to_numpy()
+    low = prices["Low"].to_numpy()
+    close = prices["Close"].to_numpy()
+    tr = np.empty(size)
+    if size:
+        tr[0] = high[0] - low[0]
+    for position in range(1, size):
+        tr[position] = max(
+            high[position] - low[position],
+            abs(high[position] - close[position - 1]),
+            abs(low[position] - close[position - 1]),
+        )
+    result = np.full(size, np.nan)
+    if size >= 20:
+        result[19] = tr[:20].mean()
+        for position in range(20, size):
+            result[position] = (19.0 * result[position - 1] + tr[position]) / 20.0
+        if (result[19:] <= 0.0).any() or not np.isfinite(result[19:]).all():
+            raise ValueError("Turtle N must be finite and strictly positive")
+    return pd.Series(result, index=prices.index, name="turtle_n_20")
+
+
+def turtle_n_entry_weight(frame: pd.DataFrame, binary_signal: pd.Series) -> pd.Series:
+    """Size next-open entries using prior-close Turtle N and freeze each holding weight."""
+    prices = _validated_frame(frame)
+    if not isinstance(binary_signal, pd.Series) or not binary_signal.index.equals(prices.index):
+        raise ValueError("binary signal index must exactly match the OHLC frame")
+    signal = pd.to_numeric(binary_signal, errors="coerce")
+    if not np.isfinite(signal.to_numpy(dtype=float)).all() or not signal.isin([0.0, 1.0]).all():
+        raise ValueError("binary signal must contain only finite 0 or 1 values")
+    n_value = _turtle_n_20(prices)
+    weight = pd.Series(0.0, index=prices.index, name="turtle_n_size_d55_20_close")
+    frozen = 0.0
+    previous = 0.0
+    for position in range(len(prices)):
+        current = float(signal.iloc[position])
+        if current == 1.0 and previous == 0.0:
+            metric_position = position - 1
+            if metric_position < 0 or pd.isna(n_value.iloc[metric_position]):
+                raise ValueError("Turtle N is unavailable at the entry signal close")
+            frozen = min(
+                1.0,
+                0.01 * prices["Close"].iloc[metric_position] / n_value.iloc[metric_position],
+            )
+        elif current == 0.0:
+            frozen = 0.0
+        weight.iloc[position] = frozen
+        previous = current
+    if not weight.between(0.0, 1.0).all():
+        raise ValueError("Turtle entry weight must remain between zero and one")
+    return weight
+
+
+def abc_round2_signals(frame: pd.DataFrame) -> dict[str, pd.Series]:
+    """Return exactly the four eligible frozen Round-2 candidates in declared order."""
+    return {
+        "d55_20_close": d55_20_close_signal(frame),
+        "ma_hys_1_200_b1": ma_hys_1_200_b1_signal(frame["Close"]),
+        "mom_12m_monthly": mom_12m_monthly_signal(frame["Close"]),
+        "dmi_adx_14_25_20": dmi_adx_14_25_20_signal(frame),
+    }
+
+
+def abc_round2_diagnostics(frame: pd.DataFrame) -> dict[str, pd.Series]:
+    """Return frozen causal diagnostics, separate from eligible candidates."""
+    breakout = d55_20_close_signal(frame)
+    return {
+        "core50_old20_10": core50_old20_10_signal(frame),
+        "turtle_n_size_d55_20_close": turtle_n_entry_weight(frame, breakout),
+    }

--- a/projects/quant-research-platform/src/gold_research/abc_round2.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2.py
@@ -31,9 +31,13 @@ def _validated_frame(frame: pd.DataFrame) -> pd.DataFrame:
     ):
         raise ValueError("OHLC prices must be finite and strictly positive")
     numeric = numeric.astype(float)
-    if (numeric["High"] < numeric["Low"]).any():
+    tolerance = numeric.abs().max(axis=1).clip(lower=1.0) * 1e-12
+    if (numeric["High"] + tolerance < numeric["Low"]).any():
         raise ValueError("OHLC High must be greater than or equal to Low")
-    if ((numeric["Close"] < numeric["Low"]) | (numeric["Close"] > numeric["High"])).any():
+    if (
+        (numeric["Close"] + tolerance < numeric["Low"])
+        | (numeric["Close"] - tolerance > numeric["High"])
+    ).any():
         raise ValueError("OHLC Close must be within the High-Low range")
     return numeric
 

--- a/projects/quant-research-platform/src/gold_research/abc_round2.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2.py
@@ -107,14 +107,14 @@ def mom_12m_monthly_signal(close: pd.Series) -> pd.Series:
             completed_month = periods[position - 1]
             comparison_month = completed_month - 12
             month_ends[completed_month] = float(prices.iloc[position - 1])
-            scored_months = pd.period_range(comparison_month, completed_month, freq="M")
-            if all(month in month_ends for month in scored_months):
+            if len(month_ends) >= 13:
+                scored_months = pd.period_range(comparison_month, completed_month, freq="M")
+                if not all(month in month_ends for month in scored_months):
+                    raise ValueError("monthly momentum requires every calendar month")
                 if month_ends[completed_month] > month_ends[comparison_month]:
                     current = 1.0
                 elif month_ends[completed_month] < month_ends[comparison_month]:
                     current = 0.0
-            else:
-                current = 0.0
         exposure.iloc[position] = current
     return exposure
 

--- a/projects/quant-research-platform/src/gold_research/abc_round2_study.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2_study.py
@@ -223,8 +223,10 @@ def _verified_symbol_frame(
     numeric = prices.apply(pd.to_numeric, errors="coerce")
     if not np.isfinite(numeric.to_numpy(dtype=float)).all() or (numeric <= 0.0).any().any():
         raise ValueError(f"normalized prices must be finite and strictly positive for {symbol}")
-    impossible_signal_geometry = (numeric["High"] < numeric["Low"]) | (
-        (numeric["Close"] < numeric["Low"]) | (numeric["Close"] > numeric["High"])
+    tolerance = numeric.abs().max(axis=1).clip(lower=1.0) * 1e-12
+    impossible_signal_geometry = (numeric["High"] + tolerance < numeric["Low"]) | (
+        (numeric["Close"] + tolerance < numeric["Low"])
+        | (numeric["Close"] - tolerance > numeric["High"])
     )
     if impossible_signal_geometry.any():
         raise ValueError(f"normalized signal OHLC relationships are invalid for {symbol}")

--- a/projects/quant-research-platform/src/gold_research/abc_round2_study.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2_study.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+import numpy as np
+import pandas as pd
+
+from .abc import adjusted_ohlc
+from .abc_round2 import abc_round2_signals
+from .abc_round2_validation import (
+    candidate_gate_decision,
+    circular_shift_timing_test,
+    constant_exposure_signal,
+    subperiod_stability,
+)
+from .backtest import backtest, metrics, trade_ledger
+from .round3 import completed_signal_close
+from .run import _data_hash, canonical_hash, get_git_state, stable_run_id
+
+TARGET_SYMBOL = "601288.SS"
+REQUIRED_SYMBOLS = (
+    TARGET_SYMBOL,
+    "601398.SS",
+    "601939.SS",
+    "601988.SS",
+    "601328.SS",
+    "601658.SS",
+    "600036.SS",
+)
+CANDIDATES = (
+    "d55_20_close",
+    "ma_hys_1_200_b1",
+    "mom_12m_monthly",
+    "dmi_adx_14_25_20",
+)
+WARMUP_SESSIONS = 315
+ARTIFACT_NAMES = (
+    "config.json",
+    "run_manifest.json",
+    "trial_registry.csv",
+    "candidate_summary.csv",
+    "benchmark_summary.csv",
+    "peer_validation.csv",
+    "target_daily_returns.csv",
+    "target_trades.csv",
+    "subperiods.csv",
+    "random_timing.json",
+    "gate_decision.json",
+    "current_signals.json",
+)
+SCENARIOS = {
+    "base": (8.0, 13.0),
+    "stress": (20.0, 25.0),
+}
+_TRIALS = (
+    {
+        "candidate": "d55_20_close",
+        "family": "donchian",
+        "parameters": {"entry_sessions": 55, "exit_sessions": 20},
+        "formula": "Enter when close exceeds the prior 55-session high; exit below the prior 20-session low.",
+    },
+    {
+        "candidate": "ma_hys_1_200_b1",
+        "family": "moving-average-hysteresis",
+        "parameters": {"sma_sessions": 200, "entry_band": 0.01, "exit_band": 0.01},
+        "formula": "Enter above 1.01 times SMA(200); exit below 0.99 times SMA(200).",
+    },
+    {
+        "candidate": "mom_12m_monthly",
+        "family": "monthly-time-series-momentum",
+        "parameters": {"lookback_month_ends": 12, "rebalance": "monthly"},
+        "formula": "At each new month, hold when the prior month-end exceeds the month-end 12 months earlier.",
+    },
+    {
+        "candidate": "dmi_adx_14_25_20",
+        "family": "directional-movement-trend-strength",
+        "parameters": {"wilder_period": 14, "entry_adx": 25, "exit_adx": 20},
+        "formula": "Enter on +DI above -DI with ADX above 25; exit on direction reversal or ADX below 20.",
+    },
+)
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, (pd.Timestamp, datetime)):
+        return pd.Timestamp(value).isoformat()
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        value = float(value)
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    if isinstance(value, float) and not np.isfinite(value):
+        raise ValueError("JSON evidence values must be finite")
+    return value
+
+
+def _json_text(value: object) -> str:
+    return (
+        json.dumps(
+            _json_value(value),
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    )
+
+
+def _analysis_day(value: pd.Timestamp | datetime | str) -> tuple[pd.Timestamp, str]:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("Asia/Shanghai")
+    else:
+        timestamp = timestamp.tz_convert("Asia/Shanghai")
+    return timestamp.tz_localize(None).normalize(), timestamp.isoformat()
+
+
+def _canonical_yahoo_url(url: object, symbol: str) -> bool:
+    parsed = urlparse(str(url))
+    try:
+        valid_port = parsed.port in (None, 443)
+    except ValueError:
+        return False
+    return bool(
+        parsed.scheme == "https"
+        and parsed.hostname == "query1.finance.yahoo.com"
+        and valid_port
+        and parsed.username is None
+        and parsed.password is None
+        and unquote(parsed.path) == f"/v8/finance/chart/{symbol}"
+        and not parsed.fragment
+    )
+
+
+def _session_dates(values: pd.Series) -> pd.DatetimeIndex:
+    parsed = pd.to_datetime(values, errors="coerce")
+    dates = pd.DatetimeIndex(parsed)
+    if dates.hasnans:
+        raise ValueError("source artifact dates must be valid and non-missing")
+    if dates.tz is not None:
+        dates = dates.tz_convert("Asia/Shanghai").tz_localize(None)
+    return dates.normalize()
+
+
+def _manifest_csv_path(data_dir: Path, value: object) -> Path:
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = data_dir / path
+    return path.resolve()
+
+
+def _verified_symbol_frame(
+    data_dir: Path,
+    symbol: str,
+    entry: object,
+    analysis_date: pd.Timestamp | datetime | str,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    required_fields = {
+        "symbol",
+        "url",
+        "csv",
+        "csv_sha256",
+        "rows",
+        "data_start",
+        "data_end",
+    }
+    if not isinstance(entry, dict) or not required_fields <= set(entry):
+        raise ValueError(f"data manifest entry for {symbol} is missing required fields")
+    if entry["symbol"] != symbol:
+        raise ValueError(f"data manifest symbol does not match {symbol}")
+    if not _canonical_yahoo_url(entry["url"], symbol):
+        raise ValueError(
+            f"source artifact URL for {symbol} is not the canonical Yahoo chart endpoint"
+        )
+
+    csv_path = _manifest_csv_path(data_dir, entry["csv"])
+    if not csv_path.is_file():
+        raise ValueError(f"source artifact CSV for {symbol} is missing")
+    csv_bytes = csv_path.read_bytes()
+    digest = hashlib.sha256(csv_bytes).hexdigest()
+    if digest != entry["csv_sha256"]:
+        raise ValueError(f"source artifact CSV checksum does not match the manifest for {symbol}")
+    try:
+        source = pd.read_csv(csv_path, float_precision="round_trip")
+    except Exception as error:
+        raise ValueError(f"source artifact CSV for {symbol} cannot be read") from error
+    if isinstance(entry["rows"], bool) or not isinstance(entry["rows"], int):
+        raise ValueError(f"source artifact row count is invalid for {symbol}")
+    if len(source) != entry["rows"]:
+        raise ValueError(f"source artifact row count does not match the manifest for {symbol}")
+    required_columns = {"Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"}
+    if not required_columns <= set(source) or source.columns.has_duplicates:
+        raise ValueError(f"source artifact columns are incomplete or duplicated for {symbol}")
+
+    dates = _session_dates(source["Date"])
+    if dates.has_duplicates:
+        raise ValueError(f"source artifact dates contain duplicates for {symbol}")
+    if not dates.is_monotonic_increasing:
+        raise ValueError(f"source artifact dates are not strictly increasing for {symbol}")
+    if (
+        entry["data_start"] != dates[0].date().isoformat()
+        or entry["data_end"] != dates[-1].date().isoformat()
+    ):
+        raise ValueError(f"source artifact date range does not match the manifest for {symbol}")
+
+    canonical = ["Open", "High", "Low", "Close", "Adj Close", "Volume"]
+    frame = source.loc[:, canonical].copy()
+    frame.index = dates
+    adjusted = adjusted_ohlc(frame)
+    prices = adjusted.loc[:, ["Open", "High", "Low", "Close", "Adj Close"]]
+    numeric = prices.apply(pd.to_numeric, errors="coerce")
+    if not np.isfinite(numeric.to_numpy(dtype=float)).all() or (numeric <= 0.0).any().any():
+        raise ValueError(f"normalized prices must be finite and strictly positive for {symbol}")
+    impossible_signal_geometry = (numeric["High"] < numeric["Low"]) | (
+        (numeric["Close"] < numeric["Low"]) | (numeric["Close"] > numeric["High"])
+    )
+    if impossible_signal_geometry.any():
+        raise ValueError(f"normalized signal OHLC relationships are invalid for {symbol}")
+    open_outside_range = (numeric["Open"] < numeric["Low"]) | (numeric["Open"] > numeric["High"])
+
+    completed_close, excluded = completed_signal_close(
+        adjusted["Close"],
+        analysis_date,
+        exchange_timezone="Asia/Shanghai",
+    )
+    completed = adjusted.reindex(completed_close.index)
+    if len(completed) <= WARMUP_SESSIONS + 120:
+        raise ValueError(f"{symbol} does not have enough completed sessions after warm-up")
+    verification = {
+        "symbol": symbol,
+        "url": str(entry["url"]),
+        "csv_sha256": digest,
+        "manifest_rows": int(entry["rows"]),
+        "manifest_data_start": str(entry["data_start"]),
+        "manifest_data_end": str(entry["data_end"]),
+        "completed_rows": len(completed),
+        "completed_data_end": completed.index[-1].date().isoformat(),
+        "open_outside_reported_range_rows": int(open_outside_range.sum()),
+        "excluded_analysis_date_or_later": bool(excluded),
+    }
+    return completed, verification
+
+
+def _load_verified_data(
+    data_dir: Path,
+    analysis_date: pd.Timestamp | datetime | str,
+) -> tuple[dict[str, pd.DataFrame], list[dict[str, object]]]:
+    manifest_path = data_dir / "data_manifest.json"
+    if not manifest_path.is_file():
+        raise ValueError("data_manifest.json is missing")
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("data_manifest.json cannot be read") from error
+    if not isinstance(manifest, dict) or set(manifest) != set(REQUIRED_SYMBOLS):
+        raise ValueError("data manifest must contain exactly the required seven-symbol universe")
+    frames: dict[str, pd.DataFrame] = {}
+    evidence = []
+    for symbol in REQUIRED_SYMBOLS:
+        frame, verification = _verified_symbol_frame(
+            data_dir, symbol, manifest[symbol], analysis_date
+        )
+        frames[symbol] = frame
+        evidence.append(verification)
+    return frames, evidence
+
+
+def _metric_row(
+    symbol: str,
+    candidate: str,
+    scenario: str,
+    result: pd.DataFrame,
+) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "candidate": candidate,
+        "scenario": scenario,
+        **metrics(result),
+    }
+
+
+def _trial_registry() -> pd.DataFrame:
+    rows = []
+    for order, trial in enumerate(_TRIALS, start=1):
+        rows.append(
+            {
+                "trial_order": order,
+                "candidate": trial["candidate"],
+                "family": trial["family"],
+                "parameters_json": json.dumps(trial["parameters"], sort_keys=True),
+                "formula": trial["formula"],
+                "eligibility": "eligible_complete_config",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _current_signals(frame: pd.DataFrame) -> dict[str, dict[str, object]]:
+    next_date = frame.index[-1] + pd.offsets.BDay(1)
+    synthetic = frame.iloc[[-1]].copy()
+    synthetic.index = pd.DatetimeIndex([next_date])
+    extended = pd.concat([frame, synthetic])
+    signals = abc_round2_signals(extended)
+    current: dict[str, dict[str, object]] = {}
+    for candidate in CANDIDATES:
+        previous = float(signals[candidate].iloc[-2])
+        target = float(signals[candidate].iloc[-1])
+        if previous <= 0.0 < target:
+            action = "BUY"
+        elif previous > 0.0 >= target:
+            action = "SELL"
+        else:
+            action = "HOLD" if target > 0.0 else "CASH"
+        current[candidate] = {
+            "signal_as_of_date": frame.index[-1].date().isoformat(),
+            "next_model_date": next_date.date().isoformat(),
+            "previous_exposure": previous,
+            "target_exposure": target,
+            "action": action,
+            "basis": "last completed real close; synthetic row only exposes next-open target",
+        }
+    return current
+
+
+def _write_csv(path: Path, frame: pd.DataFrame) -> None:
+    frame.to_csv(path, index=False, lineterminator="\n")
+
+
+def _publish_artifacts(
+    output_root: Path,
+    run_id: str,
+    json_artifacts: dict[str, object],
+    csv_artifacts: dict[str, pd.DataFrame],
+) -> Path:
+    output_root.mkdir(parents=True, exist_ok=True)
+    run_dir = output_root / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"immutable run already exists: {run_dir}")
+    temporary = Path(tempfile.mkdtemp(prefix=f".{run_id}-", dir=output_root))
+    try:
+        for name, value in json_artifacts.items():
+            (temporary / name).write_text(_json_text(value))
+        for name, frame in csv_artifacts.items():
+            _write_csv(temporary / name, frame)
+        written = {path.name for path in temporary.iterdir()}
+        if written != set(ARTIFACT_NAMES):
+            raise RuntimeError("artifact set does not match the frozen contract")
+        for path in temporary.iterdir():
+            path.chmod(0o644)
+        temporary.chmod(0o755)
+        os.rename(temporary, run_dir)
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return run_dir
+
+
+def run_abc_round2_study(
+    *,
+    data_dir: Path | str,
+    output_root: Path | str,
+    analysis_date: pd.Timestamp | datetime | str,
+    protocol_path: Path | str,
+    timing_samples: int = 10_000,
+    execution_complete: bool = False,
+) -> dict[str, object]:
+    """Run and atomically publish the frozen seven-symbol Round-2 evidence study."""
+    if (
+        isinstance(timing_samples, bool)
+        or not isinstance(timing_samples, int)
+        or timing_samples < 1
+    ):
+        raise ValueError("timing_samples must be a positive integer")
+    if not isinstance(execution_complete, bool):
+        raise ValueError("execution_complete must be bool")
+    data_dir = Path(data_dir).resolve()
+    protocol_path = Path(protocol_path).resolve()
+    if not protocol_path.is_file():
+        raise ValueError("protocol file is missing")
+    protocol_bytes = protocol_path.read_bytes()
+    protocol_hash = hashlib.sha256(protocol_bytes).hexdigest()
+    analysis_day, analysis_timestamp = _analysis_day(analysis_date)
+    frames, source_evidence = _load_verified_data(data_dir, analysis_date)
+
+    config = {
+        "version": 1,
+        "protocol_sha256": protocol_hash,
+        "analysis_timestamp": analysis_timestamp,
+        "analysis_date_shanghai": analysis_day.date().isoformat(),
+        "symbols": list(REQUIRED_SYMBOLS),
+        "target_symbol": TARGET_SYMBOL,
+        "peer_symbols": list(REQUIRED_SYMBOLS[1:]),
+        "candidates": list(CANDIDATES),
+        "warmup_sessions": WARMUP_SESSIONS,
+        "timing_samples": timing_samples,
+        "timing_minimum_shift_sessions": 60,
+        "timing_seed": 20260820,
+        "timing_family_size": 4,
+        "cost_scenarios_bps": {
+            name: {"buy": costs[0], "sell": costs[1]} for name, costs in SCENARIOS.items()
+        },
+        "scenario_interpretation": "optimistic comparability scenarios, not verified real fills",
+        "execution_complete": execution_complete,
+        "excluded_analysis_date_or_later": any(
+            bool(item["excluded_analysis_date_or_later"]) for item in source_evidence
+        ),
+        "execution": "completed close information; next available adjusted open; open-to-open return",
+        "cash_return": 0.0,
+    }
+
+    candidate_results: dict[str, dict[str, dict[str, pd.DataFrame]]] = {}
+    benchmark_results: dict[str, dict[str, dict[str, pd.DataFrame]]] = {}
+    signals_by_symbol: dict[str, dict[str, pd.Series]] = {}
+    candidate_rows: list[dict[str, object]] = []
+    benchmark_rows: list[dict[str, object]] = []
+
+    for symbol in REQUIRED_SYMBOLS:
+        frame = frames[symbol]
+        full_signals = abc_round2_signals(frame)
+        scored = frame.iloc[WARMUP_SESSIONS:]
+        signals = {name: full_signals[name].reindex(scored.index) for name in CANDIDATES}
+        signals_by_symbol[symbol] = signals
+        candidate_results[symbol] = {}
+        benchmark_results[symbol] = {}
+        for scenario, (buy_cost, sell_cost) in SCENARIOS.items():
+            candidate_results[symbol][scenario] = {}
+            benchmark_results[symbol][scenario] = {}
+            buy_hold = backtest(
+                scored["Open"],
+                pd.Series(1.0, index=scored.index),
+                buy_cost_bps=buy_cost,
+                sell_cost_bps=sell_cost,
+            )
+            cash = backtest(
+                scored["Open"],
+                pd.Series(0.0, index=scored.index),
+                buy_cost_bps=buy_cost,
+                sell_cost_bps=sell_cost,
+            )
+            benchmark_results[symbol][scenario]["buy_and_hold"] = buy_hold
+            benchmark_results[symbol][scenario]["cash_zero"] = cash
+            for benchmark, result in (("buy_and_hold", buy_hold), ("cash_zero", cash)):
+                benchmark_rows.append(
+                    {
+                        "symbol": symbol,
+                        "scenario": scenario,
+                        "candidate": "",
+                        "benchmark": benchmark,
+                        **metrics(result),
+                    }
+                )
+            for candidate in CANDIDATES:
+                result = backtest(
+                    scored["Open"],
+                    signals[candidate],
+                    buy_cost_bps=buy_cost,
+                    sell_cost_bps=sell_cost,
+                )
+                candidate_results[symbol][scenario][candidate] = result
+                constant_signal = constant_exposure_signal(signals[candidate])
+                constant = backtest(
+                    scored["Open"],
+                    constant_signal,
+                    buy_cost_bps=buy_cost,
+                    sell_cost_bps=sell_cost,
+                )
+                benchmark_results[symbol][scenario][candidate] = constant
+                benchmark_rows.append(
+                    {
+                        "symbol": symbol,
+                        "scenario": scenario,
+                        "candidate": candidate,
+                        "benchmark": "constant_exposure_matched",
+                        **metrics(constant),
+                    }
+                )
+                if symbol == TARGET_SYMBOL:
+                    row = _metric_row(symbol, candidate, scenario, result)
+                    row["buy_hold_cagr_difference"] = float(row["cagr"] - metrics(buy_hold)["cagr"])
+                    row["constant_cagr_difference"] = float(row["cagr"] - metrics(constant)["cagr"])
+                    candidate_rows.append(row)
+
+    candidate_summary = pd.DataFrame(candidate_rows)
+    benchmark_summary = pd.DataFrame(benchmark_rows)
+
+    peer_rows = []
+    peer_wins: dict[str, int] = {}
+    for candidate in CANDIDATES:
+        wins = 0
+        for peer in REQUIRED_SYMBOLS[1:]:
+            candidate_metric = metrics(candidate_results[peer]["base"][candidate])
+            buy_hold_metric = metrics(benchmark_results[peer]["base"]["buy_and_hold"])
+            improved = bool(candidate_metric["sharpe"] > buy_hold_metric["sharpe"])
+            wins += int(improved)
+            scored_index = candidate_results[peer]["base"][candidate].index
+            peer_rows.append(
+                {
+                    "candidate": candidate,
+                    "peer_symbol": peer,
+                    "evaluation_start": scored_index[0].date().isoformat(),
+                    "evaluation_end": scored_index[-1].date().isoformat(),
+                    "observations": len(scored_index),
+                    "candidate_sharpe": candidate_metric["sharpe"],
+                    "buy_hold_sharpe": buy_hold_metric["sharpe"],
+                    "sharpe_difference": candidate_metric["sharpe"] - buy_hold_metric["sharpe"],
+                    "sharpe_improved": improved,
+                }
+            )
+        peer_wins[candidate] = wins
+    peer_validation = pd.DataFrame(peer_rows)
+
+    stability: dict[str, dict[str, object]] = {}
+    subperiod_rows = []
+    for candidate in CANDIDATES:
+        summary = subperiod_stability(
+            candidate_results[TARGET_SYMBOL]["base"][candidate],
+            benchmark_results[TARGET_SYMBOL]["base"][candidate],
+        )
+        stability[candidate] = summary
+        for block in summary["blocks"]:
+            subperiod_rows.append(
+                {
+                    "candidate": candidate,
+                    "block_start": pd.Timestamp(block["start"]).date().isoformat(),
+                    "block_end": pd.Timestamp(block["end"]).date().isoformat(),
+                    "start_year": block["start_year"],
+                    "end_year": block["end_year"],
+                    "candidate_compounded_return": block["candidate_compounded_return"],
+                    "constant_compounded_return": block["constant_compounded_return"],
+                    "relative_log_return": block["relative_log_return"],
+                    "block_pass": block["pass"],
+                    "complete_blocks": summary["complete_blocks"],
+                    "positive_relative_log_blocks": summary["positive_relative_log_blocks"],
+                    "positive_fraction": summary["positive_fraction"],
+                    "stability_status": summary["status"],
+                }
+            )
+    subperiods = pd.DataFrame(subperiod_rows)
+
+    timing = {}
+    target_scored_open = frames[TARGET_SYMBOL].iloc[WARMUP_SESSIONS:]["Open"]
+    for candidate in CANDIDATES:
+        timing[candidate] = circular_shift_timing_test(
+            target_scored_open,
+            signals_by_symbol[TARGET_SYMBOL][candidate],
+            buy_cost_bps=SCENARIOS["base"][0],
+            sell_cost_bps=SCENARIOS["base"][1],
+            samples=timing_samples,
+            min_shift=60,
+            seed=20260820,
+            family_size=4,
+        )
+
+    decisions = []
+    for candidate in CANDIDATES:
+        decision = candidate_gate_decision(
+            metrics(candidate_results[TARGET_SYMBOL]["base"][candidate]),
+            metrics(candidate_results[TARGET_SYMBOL]["stress"][candidate]),
+            metrics(benchmark_results[TARGET_SYMBOL]["base"]["buy_and_hold"]),
+            metrics(benchmark_results[TARGET_SYMBOL]["base"][candidate]),
+            timing[candidate],
+            stability[candidate],
+            peer_wins[candidate],
+            execution_complete,
+        )
+        decisions.append(
+            {
+                "candidate": candidate,
+                **decision,
+                "peer_sharpe_wins_count": peer_wins[candidate],
+                "execution_complete": execution_complete,
+            }
+        )
+    gate_decision = {"candidates": decisions}
+
+    daily_frames = []
+    trade_frames = []
+    for scenario in SCENARIOS:
+        for candidate in CANDIDATES:
+            result = candidate_results[TARGET_SYMBOL][scenario][candidate]
+            daily = result.reset_index(names="date")
+            daily.insert(0, "scenario", scenario)
+            daily.insert(0, "candidate", candidate)
+            daily_frames.append(daily)
+            ledger = trade_ledger(result)
+            if not ledger.empty:
+                ledger.insert(0, "scenario", scenario)
+                ledger.insert(0, "candidate", candidate)
+                trade_frames.append(ledger)
+    target_daily = pd.concat(daily_frames, ignore_index=True)
+    target_trades = (
+        pd.concat(trade_frames, ignore_index=True)
+        if trade_frames
+        else pd.DataFrame(
+            columns=[
+                "candidate",
+                "scenario",
+                "entry_date",
+                "entry_price",
+                "exit_date",
+                "exit_price",
+                "bars",
+                "net_return",
+                "is_open",
+            ]
+        )
+    )
+    current = _current_signals(frames[TARGET_SYMBOL])
+
+    data_hash = _data_hash(frames)
+    project_root = Path(__file__).resolve().parents[2]
+    git = get_git_state(project_root)
+    identity_state = canonical_hash(
+        {
+            "git": git,
+            "protocol_sha256": protocol_hash,
+            "protocol_bytes_size": len(protocol_bytes),
+        }
+    )
+    run_id = stable_run_id(config, data_hash, identity_state)
+    run_manifest = {
+        "run_id": run_id,
+        "data_hash": data_hash,
+        "protocol_sha256": protocol_hash,
+        "protocol_bytes_size": len(protocol_bytes),
+        "git": git,
+        "source_artifacts": source_evidence,
+        "artifact_names": list(ARTIFACT_NAMES),
+        "research_only": True,
+    }
+
+    run_dir = _publish_artifacts(
+        Path(output_root).resolve(),
+        run_id,
+        {
+            "config.json": config,
+            "run_manifest.json": run_manifest,
+            "random_timing.json": timing,
+            "gate_decision.json": gate_decision,
+            "current_signals.json": current,
+        },
+        {
+            "trial_registry.csv": _trial_registry(),
+            "candidate_summary.csv": candidate_summary,
+            "benchmark_summary.csv": benchmark_summary,
+            "peer_validation.csv": peer_validation,
+            "target_daily_returns.csv": target_daily,
+            "target_trades.csv": target_trades,
+            "subperiods.csv": subperiods,
+        },
+    )
+    return {"run_id": run_id, "run_dir": str(run_dir), "config": config}

--- a/projects/quant-research-platform/src/gold_research/abc_round2_validation.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2_validation.py
@@ -37,13 +37,19 @@ def _validate_datetime_index(index: pd.Index) -> pd.DatetimeIndex:
 def non_overlapping_four_year_blocks(
     index: pd.Index,
 ) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
-    """Return complete four-calendar-year block boundaries for a scored index."""
+    """Return complete four-calendar-year block boundaries for a scored index.
+
+    Coverage in the first seven calendar days counts as a complete opening year.
+    This deterministic rule accommodates New Year market holidays without assuming
+    that every generic weekday, especially January 1, was a trading session.
+    """
     dates = _validate_datetime_index(index)
     first_year = int(dates[0].year)
     last_date = dates[-1]
     blocks: list[tuple[pd.Timestamp, pd.Timestamp]] = []
     timezone = dates.tz
-    start_year = first_year
+    starts_in_opening_week = dates[0].month == 1 and dates[0].day <= 7
+    start_year = first_year if starts_in_opening_week else first_year + 1
     while start_year + 3 <= int(last_date.year):
         end_year = start_year + 3
         calendar_end = pd.Timestamp(year=end_year, month=12, day=31, tz=timezone)
@@ -171,7 +177,12 @@ def circular_shift_timing_test(
 
     allowed_shifts = np.arange(minimum_shift, observations - minimum_shift + 1)
     rng = np.random.default_rng(int(seed))
-    shifts = rng.choice(allowed_shifts, size=sample_count, replace=True)
+    if sample_count >= len(allowed_shifts):
+        shifts = allowed_shifts
+    else:
+        shifts = rng.choice(allowed_shifts, size=sample_count, replace=False)
+    evaluated_count = len(shifts)
+    distinct_shift_count = int(np.unique(shifts).size)
     forward_returns = np.zeros(observations, dtype=float)
     forward_returns[:-1] = prices[1:] / prices[:-1] - 1.0
     elapsed_years = max(
@@ -179,12 +190,20 @@ def circular_shift_timing_test(
         max(observations - 1, 1) / 252.0,
     )
 
-    random_cagrs = np.empty(sample_count, dtype=float)
-    random_drawdowns = np.empty(sample_count, dtype=float)
+    actual_result = backtest(
+        open_price,
+        signal,
+        buy_cost_bps=buy_cost,
+        sell_cost_bps=sell_cost,
+    )
+    _validated_result_returns(actual_result, "actual timing")
+
+    random_cagrs = np.empty(evaluated_count, dtype=float)
+    random_drawdowns = np.empty(evaluated_count, dtype=float)
     positions = np.arange(observations)
     chunk_size = 256
-    for start in range(0, sample_count, chunk_size):
-        stop = min(start + chunk_size, sample_count)
+    for start in range(0, evaluated_count, chunk_size):
+        stop = min(start + chunk_size, evaluated_count)
         chunk_shifts = shifts[start:stop]
         shifted = exposures[(positions[None, :] - chunk_shifts[:, None]) % observations]
         delta = np.diff(shifted, axis=1, prepend=np.zeros((len(chunk_shifts), 1)))
@@ -193,6 +212,8 @@ def circular_shift_timing_test(
             + np.clip(-delta, 0.0, None) * sell_cost / 10_000.0
         )
         net_returns = shifted * forward_returns - costs
+        if not np.isfinite(net_returns).all() or (net_returns <= -1.0).any():
+            raise ValueError("randomized net returns must be finite and greater than negative one")
         equity = np.cumprod(1.0 + net_returns, axis=1)
         terminal = equity[:, -1]
         chunk_cagrs = np.full(len(chunk_shifts), -1.0)
@@ -202,19 +223,15 @@ def circular_shift_timing_test(
         random_cagrs[start:stop] = chunk_cagrs
         random_drawdowns[start:stop] = np.min(equity / peaks - 1.0, axis=1)
 
-    actual_metrics = metrics(
-        backtest(
-            open_price,
-            signal,
-            buy_cost_bps=buy_cost,
-            sell_cost_bps=sell_cost,
-        )
-    )
+    actual_metrics = metrics(actual_result)
     actual_cagr = float(actual_metrics["cagr"])
-    raw_p_value = float((1 + np.count_nonzero(random_cagrs >= actual_cagr)) / (sample_count + 1))
+    raw_p_value = float((1 + np.count_nonzero(random_cagrs >= actual_cagr)) / (evaluated_count + 1))
     return {
         "observations": observations,
-        "samples": sample_count,
+        "samples": evaluated_count,
+        "requested_samples": sample_count,
+        "evaluated_samples": evaluated_count,
+        "distinct_shift_count": distinct_shift_count,
         "min_shift": minimum_shift,
         "seed": int(seed),
         "family_size": family_count,
@@ -265,6 +282,10 @@ def risk_utility_pass(
     )
     if any(value is None for value in values):
         raise ValueError("risk utility metrics must be present and finite")
+    assert candidate_drawdown is not None
+    assert buy_hold_drawdown is not None
+    if not (-1.0 <= candidate_drawdown <= 0.0 and -1.0 <= buy_hold_drawdown <= 0.0):
+        raise ValueError("maximum drawdowns must be between negative one and zero")
     return bool(
         (
             candidate_sharpe > buy_hold_sharpe
@@ -287,6 +308,10 @@ def _risk_utility_status(candidate: object, buy_hold: object) -> str:
     buy_hold_sharpe = _finite_mapping_value(buy_hold, "sharpe")
     buy_hold_drawdown = _finite_mapping_value(buy_hold, "max_drawdown")
     buy_hold_calmar = _finite_mapping_value(buy_hold, "calmar")
+    if candidate_drawdown is not None and not -1.0 <= candidate_drawdown <= 0.0:
+        return "INSUFFICIENT"
+    if buy_hold_drawdown is not None and not -1.0 <= buy_hold_drawdown <= 0.0:
+        return "INSUFFICIENT"
 
     branch_one_values = (
         candidate_sharpe,
@@ -329,6 +354,8 @@ def candidate_gate_decision(
     buy_hold_cagr = _finite_mapping_value(target_buy_hold, "cagr")
     constant_cagr = _finite_mapping_value(constant_benchmark, "cagr")
     timing_p = _finite_mapping_value(timing_result, "bonferroni_p_value")
+    if timing_p is not None and not 0.0 <= timing_p <= 1.0:
+        timing_p = None
 
     base_status = _status_for_comparison(
         (base_cagr, base_sharpe),

--- a/projects/quant-research-platform/src/gold_research/abc_round2_validation.py
+++ b/projects/quant-research-platform/src/gold_research/abc_round2_validation.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+import pandas as pd
+
+from gold_research.backtest import backtest, metrics
+
+
+def constant_exposure_signal(candidate_signal: pd.Series) -> pd.Series:
+    """Return the retrospective scored-period mean exposure on every scored row."""
+    if not isinstance(candidate_signal, pd.Series) or candidate_signal.empty:
+        raise ValueError("candidate signal must be a non-empty pandas Series")
+    values = pd.to_numeric(candidate_signal, errors="coerce").astype(float)
+    if not np.isfinite(values.to_numpy()).all() or not values.between(0.0, 1.0).all():
+        raise ValueError("candidate signal must be finite and between zero and one")
+    return pd.Series(
+        float(values.mean()),
+        index=candidate_signal.index,
+        name="constant_exposure_matched",
+    )
+
+
+def _validate_datetime_index(index: pd.Index) -> pd.DatetimeIndex:
+    if (
+        not isinstance(index, pd.DatetimeIndex)
+        or index.empty
+        or index.hasnans
+        or index.has_duplicates
+        or not index.is_monotonic_increasing
+    ):
+        raise ValueError("index must be a non-empty DatetimeIndex that is unique and sorted")
+    return index
+
+
+def non_overlapping_four_year_blocks(
+    index: pd.Index,
+) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+    """Return complete four-calendar-year block boundaries for a scored index."""
+    dates = _validate_datetime_index(index)
+    first_year = int(dates[0].year)
+    last_date = dates[-1]
+    blocks: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+    timezone = dates.tz
+    start_year = first_year
+    while start_year + 3 <= int(last_date.year):
+        end_year = start_year + 3
+        calendar_end = pd.Timestamp(year=end_year, month=12, day=31, tz=timezone)
+        last_business_day = pd.offsets.BDay().rollback(calendar_end)
+        year_is_complete = end_year < int(last_date.year) or last_date >= last_business_day
+        if not year_is_complete:
+            break
+        blocks.append(
+            (
+                pd.Timestamp(year=start_year, month=1, day=1, tz=timezone),
+                calendar_end,
+            )
+        )
+        start_year += 4
+    return blocks
+
+
+def _validated_result_returns(result: pd.DataFrame, label: str) -> pd.Series:
+    if not isinstance(result, pd.DataFrame) or "net_return" not in result:
+        raise ValueError(f"{label} result must contain net_return")
+    _validate_datetime_index(result.index)
+    values = pd.to_numeric(result["net_return"], errors="coerce").astype(float)
+    if not np.isfinite(values.to_numpy()).all() or (values <= -1.0).any():
+        raise ValueError(f"{label} net returns must be finite and greater than negative one")
+    return values
+
+
+def subperiod_stability(
+    candidate_result: pd.DataFrame,
+    constant_result: pd.DataFrame,
+) -> dict[str, object]:
+    """Compare candidate and constant exposure over predeclared calendar blocks."""
+    candidate = _validated_result_returns(candidate_result, "candidate")
+    constant = _validated_result_returns(constant_result, "constant")
+    if not candidate.index.equals(constant.index):
+        raise ValueError("candidate and constant result indexes must match exactly")
+
+    rows: list[dict[str, object]] = []
+    for start, end in non_overlapping_four_year_blocks(candidate.index):
+        candidate_block = candidate.loc[start:end]
+        constant_block = constant.loc[start:end]
+        candidate_log_return = float(np.log1p(candidate_block).sum())
+        constant_log_return = float(np.log1p(constant_block).sum())
+        relative_log_return = candidate_log_return - constant_log_return
+        rows.append(
+            {
+                "start": start,
+                "end": end,
+                "start_year": int(start.year),
+                "end_year": int(end.year),
+                "candidate_compounded_return": float(np.expm1(candidate_log_return)),
+                "constant_compounded_return": float(np.expm1(constant_log_return)),
+                "relative_log_return": relative_log_return,
+                "pass": relative_log_return > 0.0,
+            }
+        )
+
+    complete_blocks = len(rows)
+    positive_blocks = sum(bool(row["pass"]) for row in rows)
+    positive_fraction = positive_blocks / complete_blocks if complete_blocks else 0.0
+    if complete_blocks < 3:
+        status = "INSUFFICIENT"
+    else:
+        status = "PASS" if positive_fraction >= 0.60 else "FAIL"
+    return {
+        "blocks": rows,
+        "complete_blocks": complete_blocks,
+        "positive_relative_log_blocks": positive_blocks,
+        "positive_fraction": float(positive_fraction),
+        "status": status,
+    }
+
+
+def _positive_integer(value: object, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return int(value)
+
+
+def _nonnegative_cost(value: object) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError("cost values must be finite and non-negative")
+    try:
+        cost = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("cost values must be finite and non-negative") from error
+    if not np.isfinite(cost) or cost < 0.0:
+        raise ValueError("cost values must be finite and non-negative")
+    return cost
+
+
+def circular_shift_timing_test(
+    open_price: pd.Series,
+    signal: pd.Series,
+    buy_cost_bps: float,
+    sell_cost_bps: float,
+    samples: int = 10_000,
+    min_shift: int = 60,
+    seed: int = 20260820,
+    family_size: int = 4,
+) -> dict[str, float | int]:
+    """Run a deterministic circular-shift timing placebo with asymmetric costs."""
+    sample_count = _positive_integer(samples, "samples")
+    minimum_shift = _positive_integer(min_shift, "min_shift")
+    family_count = _positive_integer(family_size, "family_size")
+    if isinstance(seed, (bool, np.bool_)) or not isinstance(seed, (int, np.integer)):
+        raise ValueError("seed must be an integer")
+    buy_cost = _nonnegative_cost(buy_cost_bps)
+    sell_cost = _nonnegative_cost(sell_cost_bps)
+    if not isinstance(open_price, pd.Series) or not isinstance(signal, pd.Series):
+        raise ValueError("open prices and signal must be pandas Series")
+    if not open_price.index.equals(signal.index):
+        raise ValueError("open price and signal indexes must match exactly")
+    dates = _validate_datetime_index(open_price.index)
+
+    prices = pd.to_numeric(open_price, errors="coerce").to_numpy(dtype=float)
+    exposures = pd.to_numeric(signal, errors="coerce").to_numpy(dtype=float)
+    if not np.isfinite(prices).all() or (prices <= 0.0).any():
+        raise ValueError("open prices must be finite and strictly positive")
+    if not np.isfinite(exposures).all() or (exposures < 0.0).any() or (exposures > 1.0).any():
+        raise ValueError("signal must be finite and between zero and one")
+    observations = len(prices)
+    if observations < 2 * minimum_shift:
+        raise ValueError("enough rows are required to permit the minimum circular shift")
+
+    allowed_shifts = np.arange(minimum_shift, observations - minimum_shift + 1)
+    rng = np.random.default_rng(int(seed))
+    shifts = rng.choice(allowed_shifts, size=sample_count, replace=True)
+    forward_returns = np.zeros(observations, dtype=float)
+    forward_returns[:-1] = prices[1:] / prices[:-1] - 1.0
+    elapsed_years = max(
+        (dates[-1] - dates[0]).days / 365.2425,
+        max(observations - 1, 1) / 252.0,
+    )
+
+    random_cagrs = np.empty(sample_count, dtype=float)
+    random_drawdowns = np.empty(sample_count, dtype=float)
+    positions = np.arange(observations)
+    chunk_size = 256
+    for start in range(0, sample_count, chunk_size):
+        stop = min(start + chunk_size, sample_count)
+        chunk_shifts = shifts[start:stop]
+        shifted = exposures[(positions[None, :] - chunk_shifts[:, None]) % observations]
+        delta = np.diff(shifted, axis=1, prepend=np.zeros((len(chunk_shifts), 1)))
+        costs = (
+            np.clip(delta, 0.0, None) * buy_cost / 10_000.0
+            + np.clip(-delta, 0.0, None) * sell_cost / 10_000.0
+        )
+        net_returns = shifted * forward_returns - costs
+        equity = np.cumprod(1.0 + net_returns, axis=1)
+        terminal = equity[:, -1]
+        chunk_cagrs = np.full(len(chunk_shifts), -1.0)
+        positive_terminal = terminal > 0.0
+        chunk_cagrs[positive_terminal] = terminal[positive_terminal] ** (1.0 / elapsed_years) - 1.0
+        peaks = np.maximum.accumulate(np.maximum(equity, 1.0), axis=1)
+        random_cagrs[start:stop] = chunk_cagrs
+        random_drawdowns[start:stop] = np.min(equity / peaks - 1.0, axis=1)
+
+    actual_metrics = metrics(
+        backtest(
+            open_price,
+            signal,
+            buy_cost_bps=buy_cost,
+            sell_cost_bps=sell_cost,
+        )
+    )
+    actual_cagr = float(actual_metrics["cagr"])
+    raw_p_value = float((1 + np.count_nonzero(random_cagrs >= actual_cagr)) / (sample_count + 1))
+    return {
+        "observations": observations,
+        "samples": sample_count,
+        "min_shift": minimum_shift,
+        "seed": int(seed),
+        "family_size": family_count,
+        "actual_cagr": actual_cagr,
+        "actual_max_drawdown": float(actual_metrics["max_drawdown"]),
+        "random_cagr_q05": float(np.quantile(random_cagrs, 0.05)),
+        "random_cagr_median": float(np.median(random_cagrs)),
+        "random_cagr_q95": float(np.quantile(random_cagrs, 0.95)),
+        "random_max_drawdown_q05": float(np.quantile(random_drawdowns, 0.05)),
+        "random_max_drawdown_median": float(np.median(random_drawdowns)),
+        "random_max_drawdown_q95": float(np.quantile(random_drawdowns, 0.95)),
+        "raw_p_value": raw_p_value,
+        "bonferroni_p_value": float(min(1.0, family_count * raw_p_value)),
+    }
+
+
+def _finite_mapping_value(metrics_map: object, key: str) -> float | None:
+    if not isinstance(metrics_map, Mapping) or key not in metrics_map:
+        return None
+    value = metrics_map[key]
+    if isinstance(value, (bool, np.bool_)):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if np.isfinite(numeric) else None
+
+
+def risk_utility_pass(
+    candidate_metrics: Mapping[str, object],
+    buy_hold_metrics: Mapping[str, object],
+) -> bool:
+    """Apply the frozen Round-2 risk-utility rule exactly."""
+    candidate_sharpe = _finite_mapping_value(candidate_metrics, "sharpe")
+    candidate_drawdown = _finite_mapping_value(candidate_metrics, "max_drawdown")
+    candidate_calmar = _finite_mapping_value(candidate_metrics, "calmar")
+    buy_hold_sharpe = _finite_mapping_value(buy_hold_metrics, "sharpe")
+    buy_hold_drawdown = _finite_mapping_value(buy_hold_metrics, "max_drawdown")
+    buy_hold_calmar = _finite_mapping_value(buy_hold_metrics, "calmar")
+    values = (
+        candidate_sharpe,
+        candidate_drawdown,
+        candidate_calmar,
+        buy_hold_sharpe,
+        buy_hold_drawdown,
+        buy_hold_calmar,
+    )
+    if any(value is None for value in values):
+        raise ValueError("risk utility metrics must be present and finite")
+    return bool(
+        (
+            candidate_sharpe > buy_hold_sharpe
+            and abs(candidate_drawdown) <= 0.85 * abs(buy_hold_drawdown)
+        )
+        or candidate_calmar >= buy_hold_calmar + 0.10
+    )
+
+
+def _status_for_comparison(values: tuple[float | None, ...], passed: bool) -> str:
+    if any(value is None for value in values):
+        return "INSUFFICIENT"
+    return "PASS" if passed else "FAIL"
+
+
+def _risk_utility_status(candidate: object, buy_hold: object) -> str:
+    candidate_sharpe = _finite_mapping_value(candidate, "sharpe")
+    candidate_drawdown = _finite_mapping_value(candidate, "max_drawdown")
+    candidate_calmar = _finite_mapping_value(candidate, "calmar")
+    buy_hold_sharpe = _finite_mapping_value(buy_hold, "sharpe")
+    buy_hold_drawdown = _finite_mapping_value(buy_hold, "max_drawdown")
+    buy_hold_calmar = _finite_mapping_value(buy_hold, "calmar")
+
+    branch_one_values = (
+        candidate_sharpe,
+        candidate_drawdown,
+        buy_hold_sharpe,
+        buy_hold_drawdown,
+    )
+    branch_two_values = (candidate_calmar, buy_hold_calmar)
+    branch_one = None
+    if all(value is not None for value in branch_one_values):
+        branch_one = bool(
+            candidate_sharpe > buy_hold_sharpe
+            and abs(candidate_drawdown) <= 0.85 * abs(buy_hold_drawdown)
+        )
+    branch_two = None
+    if all(value is not None for value in branch_two_values):
+        branch_two = bool(candidate_calmar >= buy_hold_calmar + 0.10)
+    if branch_one is True or branch_two is True:
+        return "PASS"
+    if branch_one is False and branch_two is False:
+        return "FAIL"
+    return "INSUFFICIENT"
+
+
+def candidate_gate_decision(
+    target_base_metrics: Mapping[str, object],
+    target_stress_metrics: Mapping[str, object],
+    target_buy_hold: Mapping[str, object],
+    constant_benchmark: Mapping[str, object],
+    timing_result: Mapping[str, object],
+    stability_summary: Mapping[str, object],
+    peer_sharpe_wins_count: int | None,
+    execution_complete: bool | None,
+) -> dict[str, object]:
+    """Evaluate all frozen Round-2 gates independently, without selecting a winner."""
+    base_cagr = _finite_mapping_value(target_base_metrics, "cagr")
+    base_sharpe = _finite_mapping_value(target_base_metrics, "sharpe")
+    stress_cagr = _finite_mapping_value(target_stress_metrics, "cagr")
+    stress_sharpe = _finite_mapping_value(target_stress_metrics, "sharpe")
+    buy_hold_cagr = _finite_mapping_value(target_buy_hold, "cagr")
+    constant_cagr = _finite_mapping_value(constant_benchmark, "cagr")
+    timing_p = _finite_mapping_value(timing_result, "bonferroni_p_value")
+
+    base_status = _status_for_comparison(
+        (base_cagr, base_sharpe),
+        bool(
+            base_cagr is not None and base_sharpe is not None and base_cagr > 0 and base_sharpe > 0
+        ),
+    )
+    stress_status = _status_for_comparison(
+        (stress_cagr, stress_sharpe),
+        bool(
+            stress_cagr is not None
+            and stress_sharpe is not None
+            and stress_cagr > 0
+            and stress_sharpe > 0
+        ),
+    )
+    retention_status = _status_for_comparison(
+        (base_cagr, buy_hold_cagr),
+        bool(
+            base_cagr is not None
+            and buy_hold_cagr is not None
+            and base_cagr >= 0.70 * buy_hold_cagr
+        ),
+    )
+    timing_status = _status_for_comparison(
+        (base_cagr, constant_cagr, timing_p),
+        bool(
+            base_cagr is not None
+            and constant_cagr is not None
+            and timing_p is not None
+            and base_cagr > constant_cagr
+            and timing_p <= 0.05
+        ),
+    )
+
+    stability = stability_summary.get("status") if isinstance(stability_summary, Mapping) else None
+    stability_status = (
+        stability if stability in {"PASS", "FAIL", "INSUFFICIENT"} else "INSUFFICIENT"
+    )
+    if peer_sharpe_wins_count is None:
+        peer_status = "INSUFFICIENT"
+    else:
+        if (
+            isinstance(peer_sharpe_wins_count, (bool, np.bool_))
+            or not isinstance(peer_sharpe_wins_count, (int, np.integer))
+            or not 0 <= peer_sharpe_wins_count <= 6
+        ):
+            raise ValueError("peer Sharpe wins count must be an integer from zero through six")
+        peer_status = "PASS" if peer_sharpe_wins_count >= 4 else "FAIL"
+    if execution_complete is None:
+        execution_status = "INSUFFICIENT"
+    elif isinstance(execution_complete, (bool, np.bool_)):
+        execution_status = "PASS" if bool(execution_complete) else "FAIL"
+    else:
+        raise ValueError("execution_complete must be bool or None")
+
+    gates = [
+        {"id": "positive_base_cagr_and_sharpe", "status": base_status},
+        {"id": "positive_stress_cagr_and_sharpe", "status": stress_status},
+        {"id": "target_cagr_at_least_70pct_buy_hold", "status": retention_status},
+        {
+            "id": "risk_utility_improvement",
+            "status": _risk_utility_status(target_base_metrics, target_buy_hold),
+        },
+        {
+            "id": "beats_constant_exposure_and_familywise_random_timing_p_le_0_05",
+            "status": timing_status,
+        },
+        {"id": "stable_across_predeclared_subperiods", "status": stability_status},
+        {
+            "id": "improves_risk_adjusted_objective_on_at_least_4_of_6_peers",
+            "status": peer_status,
+        },
+        {"id": "executable_data_and_cost_model_complete", "status": execution_status},
+    ]
+    statuses = [str(gate["status"]) for gate in gates]
+    if "FAIL" in statuses:
+        overall = "REJECTED_NO_EDGE"
+    elif "INSUFFICIENT" in statuses:
+        overall = "INSUFFICIENT_EVIDENCE"
+    else:
+        overall = "HISTORICALLY_SUPPORTED_FOR_PAPER_FORWARD"
+    return {"gates": gates, "overall": overall}

--- a/projects/quant-research-platform/src/gold_research/backtest.py
+++ b/projects/quant-research-platform/src/gold_research/backtest.py
@@ -6,22 +6,49 @@ import numpy as np
 import pandas as pd
 
 
-def backtest(open_price: pd.Series, signal: pd.Series, cost_bps: float = 5.0) -> pd.DataFrame:
+def backtest(
+    open_price: pd.Series,
+    signal: pd.Series,
+    cost_bps: float = 5.0,
+    *,
+    buy_cost_bps: float | None = None,
+    sell_cost_bps: float | None = None,
+) -> pd.DataFrame:
     """Backtest positions entered at each session's open.
 
     ``signal[t]`` must be knowable before ``open[t]``. The position then earns the
     open[t]-to-open[t+1] return. This makes a close[t-1] signal executable at the
     next available daily open without a same-close fill assumption.
+
+    ``buy_cost_bps`` and ``sell_cost_bps`` allow markets with asymmetric taxes.
+    When omitted, both sides use the legacy symmetric ``cost_bps`` value.
     """
+    raw_costs = {
+        "cost_bps": cost_bps,
+        "buy_cost_bps": cost_bps if buy_cost_bps is None else buy_cost_bps,
+        "sell_cost_bps": cost_bps if sell_cost_bps is None else sell_cost_bps,
+    }
+    if any(isinstance(value, (bool, np.bool_)) for value in raw_costs.values()):
+        raise ValueError("cost values must be finite and non-negative")
+    costs = {name: float(value) for name, value in raw_costs.items()}
+    if any(not np.isfinite(value) or value < 0.0 for value in costs.values()):
+        raise ValueError("cost values must be finite and non-negative")
+
     open_price = open_price.astype(float).dropna().rename("open")
     signal = signal.reindex(open_price.index).fillna(0.0).clip(0.0, 1.0).rename("signal")
     forward_return = open_price.shift(-1).div(open_price).sub(1.0).fillna(0.0)
     gross_return = signal * forward_return
-    turnover = signal.diff().abs()
-    if not turnover.empty:
-        turnover.iloc[0] = abs(signal.iloc[0])
-    turnover = turnover.fillna(0.0)
-    cost = turnover * cost_bps / 10_000.0
+    delta = signal.diff()
+    if not delta.empty:
+        delta.iloc[0] = signal.iloc[0]
+    delta = delta.fillna(0.0)
+    buy_turnover = delta.clip(lower=0.0)
+    sell_turnover = (-delta.clip(upper=0.0)).astype(float)
+    turnover = buy_turnover + sell_turnover
+    cost = (
+        buy_turnover * costs["buy_cost_bps"] / 10_000.0
+        + sell_turnover * costs["sell_cost_bps"] / 10_000.0
+    )
     net_return = gross_return - cost
     return pd.DataFrame(
         {
@@ -29,6 +56,8 @@ def backtest(open_price: pd.Series, signal: pd.Series, cost_bps: float = 5.0) ->
             "signal": signal,
             "asset_forward_return": forward_return,
             "gross_return": gross_return,
+            "buy_turnover": buy_turnover,
+            "sell_turnover": sell_turnover,
             "turnover": turnover,
             "cost": cost,
             "net_return": net_return,

--- a/projects/quant-research-platform/src/gold_research/data.py
+++ b/projects/quant-research-platform/src/gold_research/data.py
@@ -61,7 +61,7 @@ def save_dataset(
     safe = symbol.replace("=", "_")
     csv_path = output_dir / f"{safe}.csv"
     parquet_path = output_dir / f"{safe}.parquet"
-    clean.to_csv(csv_path, index=False, float_format="%.10g")
+    clean.to_csv(csv_path, index=False, float_format="%.17g")
     clean.to_parquet(parquet_path, index=False)
     csv_digest = hashlib.sha256(csv_path.read_bytes()).hexdigest()
     parquet_digest = hashlib.sha256(parquet_path.read_bytes()).hexdigest()

--- a/projects/quant-research-platform/src/gold_research/round3.py
+++ b/projects/quant-research-platform/src/gold_research/round3.py
@@ -110,16 +110,25 @@ def _next_session_signals(close: pd.Series) -> dict[str, float]:
 
 
 def completed_signal_close(
-    close: pd.Series, analysis_date: pd.Timestamp | datetime
+    close: pd.Series,
+    analysis_date: pd.Timestamp | datetime,
+    *,
+    exchange_timezone: str | None = None,
 ) -> tuple[pd.Series, bool]:
-    """Exclude a same-date daily bar that may still be forming."""
+    """Exclude daily bars that are not completed in the exchange calendar."""
     analysis_day = pd.Timestamp(analysis_date)
     if analysis_day.tzinfo is not None:
-        analysis_day = analysis_day.tz_convert(None)
+        if exchange_timezone is not None:
+            analysis_day = analysis_day.tz_convert(exchange_timezone).tz_localize(None)
+        else:
+            analysis_day = analysis_day.tz_convert(None)
     analysis_day = analysis_day.normalize()
     observed_days = pd.DatetimeIndex(close.index)
     if observed_days.tz is not None:
-        observed_days = observed_days.tz_convert(None)
+        if exchange_timezone is not None:
+            observed_days = observed_days.tz_convert(exchange_timezone).tz_localize(None)
+        else:
+            observed_days = observed_days.tz_convert(None)
     completed = close.loc[observed_days.normalize() < analysis_day]
     if completed.empty:
         raise ValueError("no completed daily bar is available for the current signal")

--- a/projects/quant-research-platform/src/gold_research/run.py
+++ b/projects/quant-research-platform/src/gold_research/run.py
@@ -116,7 +116,7 @@ def _data_hash(data: dict[str, pd.DataFrame]) -> str:
         digest.update(symbol.encode())
         frame = data[symbol].sort_index()
         columns = [column for column in canonical if column in frame.columns]
-        digest.update(frame.loc[:, columns].to_csv(index=True, float_format="%.10g", na_rep="NA").encode())
+        digest.update(frame.loc[:, columns].to_csv(index=True, float_format="%.17g", na_rep="NA").encode())
     return digest.hexdigest()
 
 

--- a/projects/quant-research-platform/tests/test_abc.py
+++ b/projects/quant-research-platform/tests/test_abc.py
@@ -9,6 +9,8 @@ import pytest
 
 from gold_research.abc import (
     ABC_CANDIDATES,
+    ABC_PARAMETERS,
+    _strategy_chart,
     adjusted_ohlc,
     abc_candidate_signals,
     run_abc_trend_research,
@@ -252,6 +254,18 @@ def test_abc_research_rejects_noncanonical_holdout_boundary(tmp_path):
         )
 
 
+def test_strategy_chart_fails_closed_without_cjk_font(monkeypatch):
+    monkeypatch.setattr("gold_research.abc.CJK_FONT_FAMILY", None)
+    with pytest.raises(RuntimeError, match="CJK font"):
+        _strategy_chart(
+            pd.DataFrame(),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            "breakout_20_10",
+        )
+
+
 def test_research_freezes_candidate_before_holdout_and_emits_immutable_artifacts(tmp_path):
     frame = synthetic_abc(periods=2400)
     holdout_start = pd.Timestamp("2023-01-01")
@@ -267,6 +281,8 @@ def test_research_freezes_candidate_before_holdout_and_emits_immutable_artifacts
             data_manifest=manifest,
             holdout_start="2023-01-01",
             analysis_date=analysis_date,
+            buy_cost_bps=3.0,
+            sell_cost_bps=7.0,
             bootstrap_samples=200,
         )
     finally:
@@ -300,9 +316,9 @@ def test_research_freezes_candidate_before_holdout_and_emits_immutable_artifacts
     assert config["development_warmup_sessions"] == 120
     assert config["development_evaluation_start"] > frame.index[0].date().isoformat()
     assert config["execution"] == "completed close signal; next-session adjusted open fill"
-    assert config["buy_cost_bps"] == 8.0
-    assert config["sell_cost_bps"] == 13.0
-    assert config["best_frozen_candidate"] in ABC_CANDIDATES[1:]
+    assert config["buy_cost_bps"] == 3.0
+    assert config["sell_cost_bps"] == 7.0
+    assert config["best_frozen_candidate"] == "breakout_40_20"
 
     holdout = pd.read_csv(run_dir / "holdout_summary.csv")
     assert set(holdout["candidate"]) == {"buy_and_hold", config["best_frozen_candidate"]}
@@ -322,17 +338,25 @@ def test_research_freezes_candidate_before_holdout_and_emits_immutable_artifacts
     assert {"entry_date", "exit_date", "trade_return", "cumulative_return"} <= set(trade_path)
     assert trade_path["cumulative_return"].notna().all()
     chart = (run_dir / "strategy_chart.svg").read_text()
+    entry_window, exit_window = ABC_PARAMETERS[config["best_frozen_candidate"]]
     assert "<svg" in chart
-    assert "BUY" in chart and "SELL" in chart
+    assert f"买入：收盘价突破前{entry_window}日最高收盘价" in chart
+    assert f"卖出：收盘价跌破前{exit_window}日最低收盘价" in chart
 
     report = (run_dir / "report.html").read_text()
-    assert "Agricultural Bank of China" in report
-    assert "retrospective holdout" in report
-    assert "CAGR" in report
-    assert "Maximum drawdown" in report
-    assert "Buy / sell points and cumulative return" in report
+    assert '<html lang="zh-CN">' in report
+    assert "农业银行趋势交易研究" in report
+    assert "回顾性留出期" in report
+    assert "年化收益率" in report
+    assert "最大回撤" in report
+    assert "买卖点与累计收益率" in report
+    assert f"此前{entry_window}个交易日的最高收盘价" in report
+    assert f"此前{exit_window}个交易日的最低收盘价" in report
+    assert "下一交易日开盘，按策略资金100%买入" in report
+    assert "下一交易日开盘全部卖出" in report
+    assert "基础交易成本：买入3个基点，卖出7个基点" in report
     assert "data:image/svg+xml;base64," in report
-    assert "Swipe horizontally for the full table" in report
+    assert "← 横向滑动查看完整表格 →" in report
     assert "window.addEventListener('load', refreshAll)" in report
     assert "&lt;script&gt;bad()&lt;/script&gt;" in report
     assert "<script>bad()</script>" not in report

--- a/projects/quant-research-platform/tests/test_abc.py
+++ b/projects/quant-research-platform/tests/test_abc.py
@@ -1,0 +1,338 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gold_research.abc import (
+    ABC_CANDIDATES,
+    adjusted_ohlc,
+    abc_candidate_signals,
+    run_abc_trend_research,
+    select_frozen_candidate,
+)
+from gold_research.round3 import completed_signal_close
+
+
+def synthetic_abc(seed: int = 1, periods: int = 1800) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    index = pd.bdate_range("2017-01-02", periods=periods)
+    phase = np.arange(periods)
+    regime = np.where(
+        (phase // 180) % 3 == 0,
+        0.0012,
+        np.where((phase // 180) % 3 == 1, -0.0007, 0.0002),
+    )
+    close = 3.0 * np.exp(np.cumsum(regime + rng.normal(0.0, 0.009, periods)))
+    open_price = close * np.exp(rng.normal(0.0, 0.002, periods))
+    factor = np.linspace(0.72, 1.0, periods)
+    return pd.DataFrame(
+        {
+            "Open": open_price,
+            "High": np.maximum(open_price, close) * 1.005,
+            "Low": np.minimum(open_price, close) * 0.995,
+            "Close": close,
+            "Adj Close": close * factor,
+            "Volume": 1_000_000,
+        },
+        index=index,
+    )
+
+
+def verified_manifest(root: Path, frame: pd.DataFrame, name: str = "source") -> dict:
+    root.mkdir(parents=True, exist_ok=True)
+    csv_path = root / f"{name}.csv"
+    clean = frame.reset_index(names="Date")
+    clean.to_csv(csv_path, index=False, float_format="%.17g")
+    normalized = pd.DatetimeIndex(frame.index).tz_localize(None).normalize()
+    return {
+        "symbol": "601288.SS",
+        "url": "https://query1.finance.yahoo.com/v8/finance/chart/601288.SS?interval=1d",
+        "csv": str(csv_path),
+        "csv_sha256": hashlib.sha256(csv_path.read_bytes()).hexdigest(),
+        "rows": len(frame),
+        "data_start": normalized.min().date().isoformat(),
+        "data_end": normalized.max().date().isoformat(),
+    }
+
+
+def test_adjusted_ohlc_uses_vendor_adjustment_factor_for_total_return_prices():
+    frame = pd.DataFrame(
+        {
+            "Open": [100.0, 52.0],
+            "High": [102.0, 53.0],
+            "Low": [99.0, 51.0],
+            "Close": [100.0, 52.0],
+            "Adj Close": [50.0, 52.0],
+        },
+        index=pd.bdate_range("2024-01-02", periods=2),
+    )
+    got = adjusted_ohlc(frame)
+    assert got.loc[frame.index[0], "Open"] == pytest.approx(50.0)
+    assert got.loc[frame.index[0], "High"] == pytest.approx(51.0)
+    assert got.loc[frame.index[0], "Low"] == pytest.approx(49.5)
+    assert got["Close"].tolist() == [50.0, 52.0]
+
+
+@pytest.mark.parametrize("column", ["Open", "Close", "Adj Close"])
+def test_adjusted_ohlc_rejects_non_positive_or_non_finite_prices(column):
+    frame = synthetic_abc(periods=20)
+    frame.iloc[0, frame.columns.get_loc(column)] = 0.0
+    with pytest.raises(ValueError, match="finite and strictly positive"):
+        adjusted_ohlc(frame)
+
+
+def test_adjusted_ohlc_preserves_exchange_local_dates_for_timezone_aware_rows():
+    frame = synthetic_abc(periods=3)
+    frame.index = pd.DatetimeIndex(frame.index).tz_localize("Asia/Shanghai")
+    got = adjusted_ohlc(frame)
+    assert got.index[0] == frame.index[0].tz_localize(None)
+
+
+def test_adjusted_ohlc_rejects_nat_session_dates():
+    frame = synthetic_abc(periods=3)
+    frame.index = pd.DatetimeIndex([frame.index[0], pd.NaT, frame.index[2]])
+    with pytest.raises(ValueError, match="session dates"):
+        adjusted_ohlc(frame)
+
+
+def test_completed_signal_close_uses_shanghai_calendar_day_for_aware_cutoff():
+    close = pd.Series(
+        [1.0, 2.0, 3.0],
+        index=pd.DatetimeIndex(["2024-01-01", "2024-01-02", "2024-01-03"]),
+    )
+    local_cutoff = pd.Timestamp("2024-01-04 00:30", tz="Asia/Shanghai")
+    utc_cutoff = local_cutoff.tz_convert("UTC")
+    for cutoff in (local_cutoff, utc_cutoff):
+        completed, excluded = completed_signal_close(
+            close,
+            cutoff,
+            exchange_timezone="Asia/Shanghai",
+        )
+        assert completed.index[-1] == pd.Timestamp("2024-01-03")
+        assert not excluded
+
+
+def test_candidate_set_is_small_fixed_and_expresses_buy_strength_sell_weakness():
+    expected = {
+        "buy_and_hold",
+        "breakout_20_10",
+        "breakout_40_20",
+        "breakout_60_20",
+        "breakout_120_40",
+    }
+    assert set(ABC_CANDIDATES) == expected
+    assert len(ABC_CANDIDATES) == 5
+    close = synthetic_abc(periods=500)["Adj Close"]
+    signals = abc_candidate_signals(close)
+    assert list(signals) == ABC_CANDIDATES
+    assert all(signal.index.equals(close.index) for signal in signals.values())
+    assert all(set(signal.unique()) <= {0.0, 1.0} for signal in signals.values())
+
+
+def test_breakout_candidate_is_prefix_stable_and_executes_after_signal_close():
+    close = synthetic_abc(periods=500)["Adj Close"]
+    original = abc_candidate_signals(close)["breakout_40_20"]
+    altered = close.copy()
+    altered.iloc[-1] *= 100.0
+    changed = abc_candidate_signals(altered)["breakout_40_20"]
+    assert changed.iloc[-1] == original.iloc[-1]
+    pd.testing.assert_series_equal(
+        original.iloc[:420],
+        abc_candidate_signals(close.iloc[:420])["breakout_40_20"],
+    )
+
+
+def test_candidate_selection_uses_development_rows_only_and_prefers_robust_rank():
+    index = pd.bdate_range("2018-01-02", periods=600)
+    development = index[:400]
+    rows = []
+    for candidate, cagr, sharpe, calmar, turnover in [
+        ("return_only", 0.30, 0.5, 0.5, 2.0),
+        ("balanced", 0.20, 1.5, 1.5, 1.0),
+        ("risk_only", 0.10, 2.0, 2.0, 0.5),
+    ]:
+        rows.append(
+            {
+                "candidate": candidate,
+                "cagr": cagr,
+                "sharpe": sharpe,
+                "calmar": calmar,
+                "turnover": turnover,
+            }
+        )
+    selected, ranking = select_frozen_candidate(pd.DataFrame(rows))
+    assert selected == "risk_only"
+    assert ranking.iloc[0]["candidate"] == "risk_only"
+    assert development.max() < index[400]
+
+
+def test_run_hash_tracks_intraday_vendor_rows(tmp_path):
+    frame = synthetic_abc(periods=2400)
+    frame.index = frame.index + pd.Timedelta(hours=1, minutes=30)
+    analysis_date = frame.index[-1] + pd.Timedelta(days=1)
+    first = run_abc_trend_research(
+        frame,
+        tmp_path / "first",
+        symbol="601288.SS",
+        data_manifest=verified_manifest(tmp_path / "manifest-first", frame, "first"),
+        holdout_start="2023-01-01",
+        analysis_date=analysis_date,
+        bootstrap_samples=20,
+    )
+    changed = frame.copy()
+    changed.iloc[200, changed.columns.get_loc("Close")] *= 1.01
+    changed.iloc[200, changed.columns.get_loc("Adj Close")] *= 1.01
+    second = run_abc_trend_research(
+        changed,
+        tmp_path / "second",
+        symbol="601288.SS",
+        data_manifest=verified_manifest(tmp_path / "manifest-second", changed, "second"),
+        holdout_start="2023-01-01",
+        analysis_date=analysis_date,
+        bootstrap_samples=20,
+    )
+    assert first["run_id"] != second["run_id"]
+
+
+def test_abc_research_rejects_unverified_or_mislabeled_instrument(tmp_path):
+    frame = synthetic_abc(periods=20)
+    with pytest.raises(ValueError, match="601288.SS"):
+        run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="NOT_601288.SS",
+            data_manifest={"symbol": "NOT_601288.SS"},
+        )
+    with pytest.raises(ValueError, match="data manifest"):
+        run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="601288.SS",
+            data_manifest={"symbol": "NOT_601288.SS"},
+        )
+    with pytest.raises(ValueError, match="source artifact"):
+        run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="601288.SS",
+            data_manifest={
+                "symbol": "601288.SS",
+                "url": "https://query1.finance.yahoo.com/v8/finance/chart/601288.SS",
+                "csv": str(tmp_path / "missing.csv"),
+                "csv_sha256": "0" * 64,
+                "rows": len(frame),
+                "data_start": frame.index.min().date().isoformat(),
+                "data_end": frame.index.max().date().isoformat(),
+            },
+        )
+    bad_url_manifest = verified_manifest(tmp_path / "manifest-bad-url", frame, "bad-url")
+    bad_url_manifest["url"] = "https://query1.finance.yahoo.com/not-the-api/chart/601288.SS"
+    with pytest.raises(ValueError, match="Yahoo"):
+        run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="601288.SS",
+            data_manifest=bad_url_manifest,
+        )
+
+
+def test_abc_research_rejects_noncanonical_holdout_boundary(tmp_path):
+    frame = synthetic_abc(periods=2400)
+    with pytest.raises(ValueError, match="holdout"):
+        run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="601288.SS",
+            data_manifest=verified_manifest(tmp_path / "manifest-holdout", frame, "holdout"),
+            holdout_start="2024-01-01",
+        )
+
+
+def test_research_freezes_candidate_before_holdout_and_emits_immutable_artifacts(tmp_path):
+    frame = synthetic_abc(periods=2400)
+    holdout_start = pd.Timestamp("2023-01-01")
+    analysis_date = frame.index[-1] + pd.Timedelta(days=1)
+    manifest = verified_manifest(tmp_path / "manifest-main", frame, "main")
+    manifest["source"] = "<script>bad()</script>"
+    previous_umask = os.umask(0o077)
+    try:
+        result = run_abc_trend_research(
+            frame,
+            tmp_path,
+            symbol="601288.SS",
+            data_manifest=manifest,
+            holdout_start="2023-01-01",
+            analysis_date=analysis_date,
+            bootstrap_samples=200,
+        )
+    finally:
+        os.umask(previous_umask)
+
+    run_dir = tmp_path / result["run_id"]
+    required = {
+        "config.json",
+        "run_manifest.json",
+        "development_summary.csv",
+        "holdout_summary.csv",
+        "cost_stress_summary.csv",
+        "annual_returns.csv",
+        "bootstrap.json",
+        "daily_returns.csv",
+        "trades.csv",
+        "trade_path.csv",
+        "strategy_chart.svg",
+        "latest_signal.json",
+        "report.html",
+    }
+    assert required == {path.name for path in run_dir.iterdir()}
+    assert run_dir.stat().st_mode & 0o777 == 0o755
+    assert all(path.stat().st_mode & 0o777 == 0o644 for path in run_dir.iterdir())
+
+    config = json.loads((run_dir / "config.json").read_text())
+    assert config["symbol"] == "601288.SS"
+    assert config["candidate_names"] == ABC_CANDIDATES
+    assert config["holdout_start"] == holdout_start.date().isoformat()
+    assert config["selection_end"] < config["holdout_start"]
+    assert config["development_warmup_sessions"] == 120
+    assert config["development_evaluation_start"] > frame.index[0].date().isoformat()
+    assert config["execution"] == "completed close signal; next-session adjusted open fill"
+    assert config["buy_cost_bps"] == 8.0
+    assert config["sell_cost_bps"] == 13.0
+    assert config["best_frozen_candidate"] in ABC_CANDIDATES[1:]
+
+    holdout = pd.read_csv(run_dir / "holdout_summary.csv")
+    assert set(holdout["candidate"]) == {"buy_and_hold", config["best_frozen_candidate"]}
+    assert {"cagr", "cumulative_return", "max_drawdown", "sharpe", "calmar"} <= set(holdout)
+
+    bootstrap = json.loads((run_dir / "bootstrap.json").read_text())
+    assert bootstrap["strategy"] == config["best_frozen_candidate"]
+    assert bootstrap["benchmark"] == "buy_and_hold"
+    assert bootstrap["samples"] == 200
+
+    latest = json.loads((run_dir / "latest_signal.json").read_text())
+    assert latest["candidate"] == config["best_frozen_candidate"]
+    assert latest["target_exposure"] in {0.0, 1.0}
+    assert latest["action"] in {"BUY", "SELL", "HOLD", "CASH"}
+
+    trade_path = pd.read_csv(run_dir / "trade_path.csv")
+    assert {"entry_date", "exit_date", "trade_return", "cumulative_return"} <= set(trade_path)
+    assert trade_path["cumulative_return"].notna().all()
+    chart = (run_dir / "strategy_chart.svg").read_text()
+    assert "<svg" in chart
+    assert "BUY" in chart and "SELL" in chart
+
+    report = (run_dir / "report.html").read_text()
+    assert "Agricultural Bank of China" in report
+    assert "retrospective holdout" in report
+    assert "CAGR" in report
+    assert "Maximum drawdown" in report
+    assert "Buy / sell points and cumulative return" in report
+    assert "data:image/svg+xml;base64," in report
+    assert "Swipe horizontally for the full table" in report
+    assert "window.addEventListener('load', refreshAll)" in report
+    assert "&lt;script&gt;bad()&lt;/script&gt;" in report
+    assert "<script>bad()</script>" not in report

--- a/projects/quant-research-platform/tests/test_abc_round2.py
+++ b/projects/quant-research-platform/tests/test_abc_round2.py
@@ -147,9 +147,8 @@ def test_monthly_momentum_fails_closed_when_a_calendar_month_is_missing():
         values.extend([100.0, month_end])
     close = pd.Series(values, index=pd.DatetimeIndex(dates), dtype=float)
 
-    signal = mom_12m_monthly_signal(close)
-
-    assert signal.eq(0.0).all()
+    with pytest.raises(ValueError, match="calendar month"):
+        mom_12m_monthly_signal(close)
 
 
 def dmi_fixture(periods: int = 70) -> pd.DataFrame:

--- a/projects/quant-research-platform/tests/test_abc_round2.py
+++ b/projects/quant-research-platform/tests/test_abc_round2.py
@@ -1,0 +1,333 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from gold_research.abc_round2 import (
+    _dmi_adx_14,
+    _dmi_state,
+    abc_round2_diagnostics,
+    abc_round2_signals,
+    core50_old20_10_signal,
+    d55_20_close_signal,
+    dmi_adx_14_25_20_signal,
+    ma_hys_1_200_b1_signal,
+    mom_12m_monthly_signal,
+    turtle_n_entry_weight,
+)
+
+
+def ohlc_frame(close, *, high=None, low=None, start="2020-01-02"):
+    close = np.asarray(close, dtype=float)
+    if high is None:
+        high = close + 0.5
+    if low is None:
+        low = close - 0.5
+    return pd.DataFrame(
+        {
+            "High": np.asarray(high, dtype=float),
+            "Low": np.asarray(low, dtype=float),
+            "Close": close,
+        },
+        index=pd.bdate_range(start, periods=len(close)),
+    )
+
+
+def test_d55_20_uses_prior_channels_strict_comparisons_and_next_open_timing():
+    close = np.full(61, 9.0)
+    high = np.full(61, 10.0)
+    low = np.full(61, 5.0)
+    close[55] = 10.0
+    close[56] = 10.1
+    high[56] = 10.2
+    close[57] = 6.0
+    close[58] = 5.0
+    close[59] = 4.9
+    low[59] = 4.8
+    signal = d55_20_close_signal(ohlc_frame(close, high=high, low=low))
+
+    assert signal.iloc[:57].eq(0.0).all()
+    assert signal.iloc[57:60].eq(1.0).all()
+    assert signal.iloc[60] == 0.0
+
+
+def test_d55_20_is_prefix_stable_and_ignores_current_high_in_entry_channel():
+    close = np.linspace(10.0, 30.0, 90)
+    frame = ohlc_frame(close, high=close + 0.1, low=close - 0.1)
+    frame.iloc[55, frame.columns.get_loc("High")] = 1_000.0
+
+    full = d55_20_close_signal(frame)
+    prefix = d55_20_close_signal(frame.iloc[:70])
+
+    pd.testing.assert_series_equal(full.iloc[:70], prefix)
+    assert full.iloc[56] == 1.0
+
+
+def test_ma_hysteresis_observes_warmup_strict_bands_and_next_open_timing():
+    close = np.full(205, 100.0)
+    entry_equal = 1.01 * close[:199].sum() / (200.0 - 1.01)
+    close[199] = entry_equal
+    close[200] = 103.0
+    exit_equal = 0.99 * close[3:202].sum() / (200.0 - 0.99)
+    close[202] = exit_equal
+    close[203] = 90.0
+    series = pd.Series(close, index=pd.bdate_range("2020-01-02", periods=len(close)))
+
+    signal = ma_hys_1_200_b1_signal(series)
+
+    assert close[199] == pytest.approx(1.01 * series.iloc[:200].mean())
+    assert signal.iloc[:201].eq(0.0).all()
+    assert signal.iloc[201:204].eq(1.0).all()
+    assert close[202] == pytest.approx(0.99 * series.iloc[3:203].mean())
+    assert signal.iloc[204] == 0.0
+
+
+def test_ma_hysteresis_is_prefix_stable():
+    close = pd.Series(
+        np.linspace(10.0, 20.0, 260),
+        index=pd.bdate_range("2020-01-02", periods=260),
+    )
+    full = ma_hys_1_200_b1_signal(close)
+    pd.testing.assert_series_equal(full.iloc[:230], ma_hys_1_200_b1_signal(close.iloc[:230]))
+
+
+def monthly_fixture() -> pd.Series:
+    dates = []
+    values = []
+    month_ends = {
+        pd.Period("2020-01", freq="M"): 110.0,
+        pd.Period("2020-02", freq="M"): 100.0,
+        pd.Period("2020-03", freq="M"): 90.0,
+    }
+    for month in pd.period_range("2019-01", "2020-04", freq="M"):
+        first = month.start_time + pd.offsets.BMonthBegin(0)
+        last = pd.offsets.BMonthEnd().rollback(month.end_time).normalize()
+        dates.extend([first, last])
+        values.extend(
+            [
+                500.0 if month == pd.Period("2020-03", freq="M") else 100.0,
+                month_ends.get(month, 100.0),
+            ]
+        )
+    return pd.Series(values, index=pd.DatetimeIndex(dates), dtype=float)
+
+
+def test_monthly_momentum_uses_twelve_month_ends_and_changes_only_next_month():
+    close = monthly_fixture()
+    signal = mom_12m_monthly_signal(close)
+
+    february_first = close.index[close.index.to_period("M") == pd.Period("2020-02", freq="M")][0]
+    april_first = close.index[close.index.to_period("M") == pd.Period("2020-04", freq="M")][0]
+    assert signal.loc[: pd.Timestamp("2020-01-31")].eq(0.0).all()
+    assert signal.loc[february_first : april_first - pd.Timedelta(days=1)].eq(1.0).all()
+    assert signal.loc[april_first] == 0.0
+
+
+def test_monthly_momentum_equality_retains_state_and_is_prefix_stable():
+    close = monthly_fixture()
+    full = mom_12m_monthly_signal(close)
+    march_rows = close.index.to_period("M") == pd.Period("2020-03", freq="M")
+
+    assert full.loc[close.index[march_rows][0]] == 1.0
+    prefix = close.iloc[:-1]
+    pd.testing.assert_series_equal(full.iloc[:-1], mom_12m_monthly_signal(prefix))
+
+
+def reference_dmi(frame: pd.DataFrame, period: int = 14) -> pd.DataFrame:
+    high = frame["High"].to_numpy(dtype=float)
+    low = frame["Low"].to_numpy(dtype=float)
+    close = frame["Close"].to_numpy(dtype=float)
+    size = len(frame)
+    tr = np.full(size, np.nan)
+    plus_dm = np.full(size, np.nan)
+    minus_dm = np.full(size, np.nan)
+    for position in range(1, size):
+        tr[position] = max(
+            high[position] - low[position],
+            abs(high[position] - close[position - 1]),
+            abs(low[position] - close[position - 1]),
+        )
+        up = high[position] - high[position - 1]
+        down = low[position - 1] - low[position]
+        plus_dm[position] = up if up > down and up > 0.0 else 0.0
+        minus_dm[position] = down if down > up and down > 0.0 else 0.0
+
+    smooth_tr = np.full(size, np.nan)
+    smooth_plus = np.full(size, np.nan)
+    smooth_minus = np.full(size, np.nan)
+    if size > period:
+        smooth_tr[period] = tr[1 : period + 1].sum()
+        smooth_plus[period] = plus_dm[1 : period + 1].sum()
+        smooth_minus[period] = minus_dm[1 : period + 1].sum()
+        for position in range(period + 1, size):
+            smooth_tr[position] = (
+                smooth_tr[position - 1] - smooth_tr[position - 1] / period + tr[position]
+            )
+            smooth_plus[position] = (
+                smooth_plus[position - 1] - smooth_plus[position - 1] / period + plus_dm[position]
+            )
+            smooth_minus[position] = (
+                smooth_minus[position - 1]
+                - smooth_minus[position - 1] / period
+                + minus_dm[position]
+            )
+    plus_di = 100.0 * smooth_plus / smooth_tr
+    minus_di = 100.0 * smooth_minus / smooth_tr
+    dx = 100.0 * np.abs(plus_di - minus_di) / (plus_di + minus_di)
+    adx = np.full(size, np.nan)
+    first_adx = 2 * period - 1
+    if size > first_adx:
+        adx[first_adx] = dx[period : first_adx + 1].mean()
+        for position in range(first_adx + 1, size):
+            adx[position] = ((period - 1) * adx[position - 1] + dx[position]) / period
+    return pd.DataFrame({"+DI": plus_di, "-DI": minus_di, "DX": dx, "ADX": adx}, index=frame.index)
+
+
+def dmi_fixture(periods: int = 70) -> pd.DataFrame:
+    moves = np.resize(np.array([1.2, 0.8, -0.3, 1.5, -0.6, 0.4]), periods)
+    close = 100.0 + np.cumsum(moves)
+    width = np.resize(np.array([0.7, 1.1, 0.9, 1.3]), periods)
+    return ohlc_frame(close, high=close + width, low=close - width)
+
+
+def test_dmi_adx_matches_reference_and_has_exact_wilder_warmup():
+    frame = dmi_fixture()
+    expected = reference_dmi(frame)
+    actual = _dmi_adx_14(frame)
+
+    assert actual["ADX"].iloc[:27].isna().all()
+    assert actual["ADX"].iloc[27:].notna().all()
+    pd.testing.assert_frame_equal(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_dmi_adx_signal_enters_only_after_completed_first_adx_close():
+    close = np.arange(100.0, 140.0)
+    frame = ohlc_frame(close, high=close + 0.5, low=close - 0.5)
+    signal = dmi_adx_14_25_20_signal(frame)
+
+    assert signal.iloc[:28].eq(0.0).all()
+    assert signal.iloc[28:].eq(1.0).all()
+
+
+def test_dmi_state_retains_adx_threshold_equality_but_exits_on_direction_equality():
+    index = pd.bdate_range("2024-01-02", periods=4)
+    plus_di = pd.Series([30.0, 30.0, 30.0, 10.0], index=index)
+    minus_di = pd.Series([10.0, 10.0, 10.0, 10.0], index=index)
+    adx = pd.Series([25.0, 26.0, 20.0, 20.0], index=index)
+
+    state = _dmi_state(plus_di, minus_di, adx)
+
+    assert state.tolist() == [0.0, 1.0, 1.0, 0.0]
+
+
+@pytest.mark.parametrize("bad", [0.0, np.nan, np.inf])
+def test_dmi_adx_rejects_invalid_ohlc(bad):
+    frame = dmi_fixture()
+    frame.iloc[3, frame.columns.get_loc("High")] = bad
+    with pytest.raises(ValueError, match="finite and strictly positive"):
+        dmi_adx_14_25_20_signal(frame)
+
+
+def test_dmi_adx_rejects_duplicate_and_non_monotonic_dates():
+    duplicate = dmi_fixture()
+    duplicate.index = duplicate.index.where(
+        duplicate.index != duplicate.index[3], duplicate.index[2]
+    )
+    with pytest.raises(ValueError, match="duplicates"):
+        dmi_adx_14_25_20_signal(duplicate)
+
+    reversed_frame = dmi_fixture().iloc[::-1]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        dmi_adx_14_25_20_signal(reversed_frame)
+
+
+def test_dmi_adx_signal_is_prefix_stable():
+    frame = dmi_fixture()
+    full = dmi_adx_14_25_20_signal(frame)
+    pd.testing.assert_series_equal(full.iloc[:55], dmi_adx_14_25_20_signal(frame.iloc[:55]))
+
+
+def test_core50_old20_10_maps_off_on_to_half_and_full_with_next_open_delay():
+    close = np.full(26, 9.0)
+    high = np.full(26, 10.0)
+    low = np.full(26, 5.0)
+    close[20] = 10.0
+    close[21] = 10.1
+    high[21] = 10.2
+    close[22] = 6.0
+    close[23] = 5.0
+    close[24] = 4.9
+    low[24] = 4.8
+
+    weight = core50_old20_10_signal(ohlc_frame(close, high=high, low=low))
+
+    assert weight.iloc[:22].eq(0.5).all()
+    assert weight.iloc[22:25].eq(1.0).all()
+    assert weight.iloc[25] == 0.5
+
+
+def reference_turtle_n(frame: pd.DataFrame) -> pd.Series:
+    high = frame["High"].to_numpy(dtype=float)
+    low = frame["Low"].to_numpy(dtype=float)
+    close = frame["Close"].to_numpy(dtype=float)
+    tr = np.empty(len(frame))
+    tr[0] = high[0] - low[0]
+    for position in range(1, len(frame)):
+        tr[position] = max(
+            high[position] - low[position],
+            abs(high[position] - close[position - 1]),
+            abs(low[position] - close[position - 1]),
+        )
+    result = np.full(len(frame), np.nan)
+    result[19] = tr[:20].mean()
+    for position in range(20, len(frame)):
+        result[position] = (19.0 * result[position - 1] + tr[position]) / 20.0
+    return pd.Series(result, index=frame.index)
+
+
+def test_turtle_n_weight_uses_prior_signal_close_and_freezes_each_holding_segment():
+    close = np.full(35, 100.0)
+    width = np.linspace(0.5, 5.0, len(close))
+    frame = ohlc_frame(close, high=close + width, low=close - width)
+    binary = pd.Series(0.0, index=frame.index)
+    binary.iloc[21:27] = 1.0
+    binary.iloc[28:33] = 1.0
+    n_value = reference_turtle_n(frame)
+
+    weight = turtle_n_entry_weight(frame, binary)
+
+    first = min(1.0, 0.01 * close[20] / n_value.iloc[20])
+    second = min(1.0, 0.01 * close[27] / n_value.iloc[27])
+    assert weight.iloc[21:27].eq(first).all()
+    assert weight.iloc[27] == 0.0
+    assert weight.iloc[28:33].eq(second).all()
+    assert first != second
+    assert weight.between(0.0, 1.0).all()
+
+
+def test_turtle_n_weight_rejects_nonbinary_or_misaligned_signal():
+    frame = dmi_fixture(40)
+    nonbinary = pd.Series(0.0, index=frame.index)
+    nonbinary.iloc[25] = 1.2
+    with pytest.raises(ValueError, match="binary"):
+        turtle_n_entry_weight(frame, nonbinary)
+
+    with pytest.raises(ValueError, match="index"):
+        turtle_n_entry_weight(frame, nonbinary.reset_index(drop=True))
+
+
+def test_round2_registry_contains_exactly_four_eligible_candidates_in_frozen_order():
+    frame = dmi_fixture(320)
+
+    candidates = abc_round2_signals(frame)
+    diagnostics = abc_round2_diagnostics(frame)
+
+    assert list(candidates) == [
+        "d55_20_close",
+        "ma_hys_1_200_b1",
+        "mom_12m_monthly",
+        "dmi_adx_14_25_20",
+    ]
+    assert len(candidates) == 4
+    assert list(diagnostics) == ["core50_old20_10", "turtle_n_size_d55_20_close"]
+    assert set(candidates).isdisjoint(diagnostics)
+    assert all(signal.index.equals(frame.index) for signal in candidates.values())

--- a/projects/quant-research-platform/tests/test_abc_round2.py
+++ b/projects/quant-research-platform/tests/test_abc_round2.py
@@ -197,6 +197,18 @@ def test_dmi_state_retains_adx_threshold_equality_but_exits_on_direction_equalit
     assert state.tolist() == [0.0, 1.0, 1.0, 0.0]
 
 
+def test_signal_validation_allows_machine_roundoff_at_range_boundary():
+    high = np.full(60, 10.0)
+    low = np.full(60, 9.0)
+    close = np.full(60, 10.0)
+    close[10] = np.nextafter(10.0, np.inf)
+    frame = ohlc_frame(close, high=high, low=low)
+
+    signal = d55_20_close_signal(frame)
+
+    assert len(signal) == len(frame)
+
+
 @pytest.mark.parametrize("bad", [0.0, np.nan, np.inf])
 def test_dmi_adx_rejects_invalid_ohlc(bad):
     frame = dmi_fixture()

--- a/projects/quant-research-platform/tests/test_abc_round2.py
+++ b/projects/quant-research-platform/tests/test_abc_round2.py
@@ -132,54 +132,24 @@ def test_monthly_momentum_equality_retains_state_and_is_prefix_stable():
     pd.testing.assert_series_equal(full.iloc[:-1], mom_12m_monthly_signal(prefix))
 
 
-def reference_dmi(frame: pd.DataFrame, period: int = 14) -> pd.DataFrame:
-    high = frame["High"].to_numpy(dtype=float)
-    low = frame["Low"].to_numpy(dtype=float)
-    close = frame["Close"].to_numpy(dtype=float)
-    size = len(frame)
-    tr = np.full(size, np.nan)
-    plus_dm = np.full(size, np.nan)
-    minus_dm = np.full(size, np.nan)
-    for position in range(1, size):
-        tr[position] = max(
-            high[position] - low[position],
-            abs(high[position] - close[position - 1]),
-            abs(low[position] - close[position - 1]),
-        )
-        up = high[position] - high[position - 1]
-        down = low[position - 1] - low[position]
-        plus_dm[position] = up if up > down and up > 0.0 else 0.0
-        minus_dm[position] = down if down > up and down > 0.0 else 0.0
+def test_monthly_momentum_fails_closed_when_a_calendar_month_is_missing():
+    dates = []
+    values = []
+    for month in pd.period_range("2018-12", "2020-02", freq="M"):
+        if month == pd.Period("2019-07", freq="M"):
+            continue
+        first = month.start_time + pd.offsets.BMonthBegin(0)
+        last = pd.offsets.BMonthEnd().rollback(month.end_time).normalize()
+        dates.extend([first, last])
+        month_end = 90.0 if month == pd.Period("2018-12", freq="M") else 100.0
+        if month == pd.Period("2020-01", freq="M"):
+            month_end = 110.0
+        values.extend([100.0, month_end])
+    close = pd.Series(values, index=pd.DatetimeIndex(dates), dtype=float)
 
-    smooth_tr = np.full(size, np.nan)
-    smooth_plus = np.full(size, np.nan)
-    smooth_minus = np.full(size, np.nan)
-    if size > period:
-        smooth_tr[period] = tr[1 : period + 1].sum()
-        smooth_plus[period] = plus_dm[1 : period + 1].sum()
-        smooth_minus[period] = minus_dm[1 : period + 1].sum()
-        for position in range(period + 1, size):
-            smooth_tr[position] = (
-                smooth_tr[position - 1] - smooth_tr[position - 1] / period + tr[position]
-            )
-            smooth_plus[position] = (
-                smooth_plus[position - 1] - smooth_plus[position - 1] / period + plus_dm[position]
-            )
-            smooth_minus[position] = (
-                smooth_minus[position - 1]
-                - smooth_minus[position - 1] / period
-                + minus_dm[position]
-            )
-    plus_di = 100.0 * smooth_plus / smooth_tr
-    minus_di = 100.0 * smooth_minus / smooth_tr
-    dx = 100.0 * np.abs(plus_di - minus_di) / (plus_di + minus_di)
-    adx = np.full(size, np.nan)
-    first_adx = 2 * period - 1
-    if size > first_adx:
-        adx[first_adx] = dx[period : first_adx + 1].mean()
-        for position in range(first_adx + 1, size):
-            adx[position] = ((period - 1) * adx[position - 1] + dx[position]) / period
-    return pd.DataFrame({"+DI": plus_di, "-DI": minus_di, "DX": dx, "ADX": adx}, index=frame.index)
+    signal = mom_12m_monthly_signal(close)
+
+    assert signal.eq(0.0).all()
 
 
 def dmi_fixture(periods: int = 70) -> pd.DataFrame:
@@ -189,14 +159,23 @@ def dmi_fixture(periods: int = 70) -> pd.DataFrame:
     return ohlc_frame(close, high=close + width, low=close - width)
 
 
-def test_dmi_adx_matches_reference_and_has_exact_wilder_warmup():
+def test_dmi_adx_matches_talib_0_6_7_points_and_exact_wilder_warmup():
     frame = dmi_fixture()
-    expected = reference_dmi(frame)
     actual = _dmi_adx_14(frame)
 
     assert actual["ADX"].iloc[:27].isna().all()
     assert actual["ADX"].iloc[27:].notna().all()
-    pd.testing.assert_frame_equal(actual, expected, rtol=1e-12, atol=1e-12)
+    assert actual.iloc[14]["+DI"] == pytest.approx(35.88541666666655, rel=1e-12, abs=1e-12)
+    assert actual.iloc[14]["-DI"] == pytest.approx(2.057291666666842, rel=1e-12, abs=1e-12)
+    assert actual.iloc[14]["DX"] == pytest.approx(89.15579958819401, rel=1e-12, abs=1e-12)
+    assert np.isnan(actual.iloc[14]["ADX"])
+    assert actual.iloc[27]["+DI"] == pytest.approx(38.55678552886503, rel=1e-12, abs=1e-12)
+    assert actual.iloc[27]["-DI"] == pytest.approx(1.9898397363845517, rel=1e-12, abs=1e-12)
+    assert actual.iloc[27]["DX"] == pytest.approx(90.18493044307714, rel=1e-12, abs=1e-12)
+    assert actual.iloc[27]["ADX"] == pytest.approx(90.63333449919035, rel=1e-12, abs=1e-12)
+    assert actual.iloc[28]["ADX"] == pytest.approx(90.6013056380394, rel=1e-12, abs=1e-12)
+    assert actual.iloc[40]["ADX"] == pytest.approx(90.21533860650113, rel=1e-12, abs=1e-12)
+    assert actual.iloc[69]["ADX"] == pytest.approx(90.4833624970207, rel=1e-12, abs=1e-12)
 
 
 def test_dmi_adx_signal_enters_only_after_completed_first_adx_close():
@@ -225,6 +204,32 @@ def test_dmi_adx_rejects_invalid_ohlc(bad):
     frame.iloc[3, frame.columns.get_loc("High")] = bad
     with pytest.raises(ValueError, match="finite and strictly positive"):
         dmi_adx_14_25_20_signal(frame)
+
+
+def test_signal_validation_rejects_empty_ohlc_and_close_inputs():
+    empty_index = pd.DatetimeIndex([])
+    empty_frame = pd.DataFrame(columns=["High", "Low", "Close"], index=empty_index)
+    empty_close = pd.Series(index=empty_index, dtype=float)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        d55_20_close_signal(empty_frame)
+    with pytest.raises(ValueError, match="must not be empty"):
+        ma_hys_1_200_b1_signal(empty_close)
+
+
+@pytest.mark.parametrize(
+    ("high", "low", "close"),
+    [
+        (9.0, 10.0, 9.5),
+        (10.0, 9.0, 10.1),
+        (10.0, 9.0, 8.9),
+    ],
+)
+def test_signal_validation_rejects_impossible_ohlc_bars(high, low, close):
+    frame = ohlc_frame([close], high=[high], low=[low])
+
+    with pytest.raises(ValueError, match="High.*Low|Close.*range"):
+        d55_20_close_signal(frame)
 
 
 def test_dmi_adx_rejects_duplicate_and_non_monotonic_dates():

--- a/projects/quant-research-platform/tests/test_abc_round2_study.py
+++ b/projects/quant-research-platform/tests/test_abc_round2_study.py
@@ -1,0 +1,304 @@
+import hashlib
+import json
+import shutil
+import stat
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gold_research.abc_round2_study import (
+    CANDIDATES,
+    REQUIRED_SYMBOLS,
+    run_abc_round2_study,
+)
+
+
+ARTIFACTS = {
+    "config.json",
+    "run_manifest.json",
+    "trial_registry.csv",
+    "candidate_summary.csv",
+    "benchmark_summary.csv",
+    "peer_validation.csv",
+    "target_daily_returns.csv",
+    "target_trades.csv",
+    "subperiods.csv",
+    "random_timing.json",
+    "gate_decision.json",
+    "current_signals.json",
+}
+
+
+def _price_frame(index: pd.DatetimeIndex, phase: float) -> pd.DataFrame:
+    position = np.arange(len(index), dtype=float)
+    close = 20.0 * np.exp(0.00012 * position + 0.08 * np.sin(position / 37.0 + phase))
+    open_price = close * (1.0 + 0.003 * np.sin(position / 11.0 + phase))
+    high = np.maximum(open_price, close) * 1.01
+    low = np.minimum(open_price, close) * 0.99
+    adjustment = 0.55 + 0.45 * position / max(len(index) - 1, 1)
+    frame = pd.DataFrame(
+        {
+            "Open": open_price,
+            "Volume": (1_000_000 + position).astype(int),
+            "Close": close,
+            "High": high,
+            "Low": low,
+            "Date": index.strftime("%Y-%m-%d 01:30:00"),
+            "Adj Close": close * adjustment,
+        }
+    )
+    frame.loc[frame.index[500], "Open"] = frame.loc[frame.index[500], "High"] * 1.02
+    return frame
+
+
+def _write_manifest(data_dir: Path, frames: dict[str, pd.DataFrame]) -> None:
+    manifest = {}
+    for symbol, frame in frames.items():
+        csv_path = data_dir / f"{symbol}.csv"
+        frame.to_csv(csv_path, index=False)
+        dates = pd.to_datetime(frame["Date"])
+        manifest[symbol] = {
+            "symbol": symbol,
+            "url": (
+                f"https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
+                "?period1=1&period2=2&interval=1d&events=history"
+            ),
+            "csv": str(csv_path),
+            "csv_sha256": hashlib.sha256(csv_path.read_bytes()).hexdigest(),
+            "rows": len(frame),
+            "data_start": dates.min().date().isoformat(),
+            "data_end": dates.max().date().isoformat(),
+        }
+    (data_dir / "data_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def round2_inputs(tmp_path_factory):
+    root = tmp_path_factory.mktemp("abc-round2-inputs")
+    data_dir = root / "data"
+    data_dir.mkdir()
+    analysis_date = pd.Timestamp("2026-08-20 13:00:00", tz="Asia/Shanghai")
+    full_index = pd.bdate_range(end=analysis_date.tz_localize(None).normalize(), periods=3_900)
+    frames = {}
+    for position, symbol in enumerate(REQUIRED_SYMBOLS):
+        index = full_index
+        if symbol == "601658.SS":
+            index = full_index[full_index >= pd.Timestamp("2019-12-10")]
+        frames[symbol] = _price_frame(index, position / 3.0)
+    _write_manifest(data_dir, frames)
+    protocol = root / "protocol.yaml"
+    protocol.write_text("version: 1\nprotocol_id: synthetic-round2\n")
+    return data_dir, protocol, analysis_date
+
+
+def _clone_data_dir(source: Path, destination: Path) -> Path:
+    shutil.copytree(source, destination)
+    manifest_path = destination / "data_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for symbol, entry in manifest.items():
+        entry["csv"] = str(destination / f"{symbol}.csv")
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return destination
+
+
+@pytest.mark.parametrize("tamper", ["checksum", "url", "rows"])
+def test_runner_rejects_tampered_manifest_evidence(round2_inputs, tmp_path, tamper):
+    source, protocol, analysis_date = round2_inputs
+    data_dir = _clone_data_dir(source, tmp_path / "data")
+    manifest_path = data_dir / "data_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    target = manifest["601288.SS"]
+    if tamper == "checksum":
+        target["csv_sha256"] = "0" * 64
+    elif tamper == "url":
+        target["url"] = target["url"].replace("601288.SS", "601398.SS")
+    else:
+        target["rows"] += 1
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    with pytest.raises(ValueError, match="checksum|canonical Yahoo|row count"):
+        run_abc_round2_study(
+            data_dir=data_dir,
+            output_root=tmp_path / "runs",
+            analysis_date=analysis_date,
+            protocol_path=protocol,
+            timing_samples=3,
+        )
+
+
+def test_runner_writes_complete_non_html_evidence_and_independent_gates(round2_inputs, tmp_path):
+    data_dir, protocol, analysis_date = round2_inputs
+
+    result = run_abc_round2_study(
+        data_dir=data_dir,
+        output_root=tmp_path / "runs",
+        analysis_date=analysis_date,
+        protocol_path=protocol,
+        timing_samples=7,
+    )
+    run_dir = Path(result["run_dir"])
+
+    assert {path.name for path in run_dir.iterdir()} == ARTIFACTS
+    assert stat.S_IMODE(run_dir.stat().st_mode) == 0o755
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o644 for path in run_dir.iterdir())
+    assert not list(run_dir.glob("*.html"))
+
+    config = json.loads((run_dir / "config.json").read_text())
+    manifest = json.loads((run_dir / "run_manifest.json").read_text())
+    timing = json.loads((run_dir / "random_timing.json").read_text())
+    decisions = json.loads((run_dir / "gate_decision.json").read_text())
+    current = json.loads((run_dir / "current_signals.json").read_text())
+    for path in run_dir.glob("*.json"):
+        text = path.read_text()
+        assert "NaN" not in text
+        assert "Infinity" not in text
+
+    assert config["symbols"] == list(REQUIRED_SYMBOLS)
+    assert config["candidates"] == list(CANDIDATES)
+    assert config["warmup_sessions"] == 315
+    assert config["execution_complete"] is False
+    assert config["excluded_analysis_date_or_later"] is True
+    assert manifest["run_id"] == result["run_id"]
+    assert manifest["protocol_sha256"] == hashlib.sha256(protocol.read_bytes()).hexdigest()
+    assert "winner" not in json.dumps(decisions).lower()
+    assert "best" not in json.dumps(decisions).lower()
+
+    registry = pd.read_csv(run_dir / "trial_registry.csv")
+    candidates = pd.read_csv(run_dir / "candidate_summary.csv")
+    benchmarks = pd.read_csv(run_dir / "benchmark_summary.csv")
+    peers = pd.read_csv(run_dir / "peer_validation.csv")
+    daily = pd.read_csv(run_dir / "target_daily_returns.csv")
+    trades = pd.read_csv(run_dir / "target_trades.csv")
+    subperiods = pd.read_csv(run_dir / "subperiods.csv")
+
+    assert registry["candidate"].tolist() == list(CANDIDATES)
+    assert len(registry) == 4
+    assert set(candidates["candidate"]) == set(CANDIDATES)
+    assert set(candidates["scenario"]) == {"base", "stress"}
+    assert len(candidates) == 8
+    assert set(benchmarks["benchmark"]) == {
+        "buy_and_hold",
+        "cash_zero",
+        "constant_exposure_matched",
+    }
+    assert len(peers) == 24
+    assert set(peers["peer_symbol"]) == set(REQUIRED_SYMBOLS[1:])
+    assert set(daily["candidate"]) == set(CANDIDATES)
+    assert set(daily["scenario"]) == {"base", "stress"}
+    assert set(trades["candidate"]).issubset(CANDIDATES)
+    assert set(trades["scenario"]).issubset({"base", "stress"})
+    assert set(subperiods["candidate"]) == set(CANDIDATES)
+
+    late_peer = peers.loc[peers["peer_symbol"] == "601658.SS"]
+    source_dates = pd.to_datetime(pd.read_csv(data_dir / "601658.SS.csv")["Date"])
+    assert late_peer["evaluation_start"].nunique() == 1
+    assert late_peer["evaluation_start"].iloc[0] == source_dates.iloc[315].date().isoformat()
+
+    assert set(timing) == set(CANDIDATES)
+    assert all(item["requested_samples"] == 7 for item in timing.values())
+    assert all(item["evaluated_samples"] == 7 for item in timing.values())
+    assert all(item["distinct_shift_count"] == 7 for item in timing.values())
+    assert set(current) == set(CANDIDATES)
+    assert all(
+        item["signal_as_of_date"] < analysis_date.date().isoformat() for item in current.values()
+    )
+    assert all(item["target_exposure"] in {0.0, 1.0} for item in current.values())
+
+    decision_rows = decisions["candidates"]
+    assert [row["candidate"] for row in decision_rows] == list(CANDIDATES)
+    assert all(len(row["gates"]) == 8 for row in decision_rows)
+    assert all(row["gates"][-1]["status"] == "FAIL" for row in decision_rows)
+    for row in decision_rows:
+        candidate = row["candidate"]
+        wins = int(peers.loc[peers["candidate"] == candidate, "sharpe_improved"].sum())
+        peer_gate = next(
+            gate
+            for gate in row["gates"]
+            if gate["id"] == "improves_risk_adjusted_objective_on_at_least_4_of_6_peers"
+        )
+        assert peer_gate["status"] == ("PASS" if wins >= 4 else "FAIL")
+        stability_gate = next(
+            gate for gate in row["gates"] if gate["id"] == "stable_across_predeclared_subperiods"
+        )
+        candidate_blocks = subperiods.loc[subperiods["candidate"] == candidate]
+        assert stability_gate["status"] == candidate_blocks["stability_status"].iloc[0]
+
+
+def test_partial_analysis_day_cannot_change_scored_data_or_current_target(round2_inputs, tmp_path):
+    source, protocol, analysis_date = round2_inputs
+    changed = _clone_data_dir(source, tmp_path / "changed")
+    target_path = changed / "601288.SS.csv"
+    lines = target_path.read_text().splitlines()
+    columns = lines[0].split(",")
+    values = lines[-1].split(",")
+    replacements = {
+        "Open": "1000.0",
+        "High": "1100.0",
+        "Low": "900.0",
+        "Close": "1050.0",
+        "Adj Close": "1050.0",
+    }
+    for column, value in replacements.items():
+        values[columns.index(column)] = value
+    lines[-1] = ",".join(values)
+    target_path.write_text("\n".join(lines) + "\n")
+    manifest_path = changed / "data_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["601288.SS"]["csv_sha256"] = hashlib.sha256(target_path.read_bytes()).hexdigest()
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    original_result = run_abc_round2_study(
+        data_dir=source,
+        output_root=tmp_path / "original-runs",
+        analysis_date=analysis_date,
+        protocol_path=protocol,
+        timing_samples=3,
+    )
+    changed_result = run_abc_round2_study(
+        data_dir=changed,
+        output_root=tmp_path / "changed-runs",
+        analysis_date=analysis_date,
+        protocol_path=protocol,
+        timing_samples=3,
+    )
+
+    assert original_result["run_id"] == changed_result["run_id"]
+    original_dir = Path(original_result["run_dir"])
+    changed_dir = Path(changed_result["run_dir"])
+    for artifact in (
+        "candidate_summary.csv",
+        "target_daily_returns.csv",
+        "current_signals.json",
+        "random_timing.json",
+        "gate_decision.json",
+    ):
+        assert (original_dir / artifact).read_bytes() == (changed_dir / artifact).read_bytes()
+
+
+def test_run_id_and_artifacts_are_reproducible_and_existing_run_is_immutable(
+    round2_inputs, tmp_path
+):
+    data_dir, protocol, analysis_date = round2_inputs
+    kwargs = {
+        "data_dir": data_dir,
+        "analysis_date": analysis_date,
+        "protocol_path": protocol,
+        "timing_samples": 3,
+    }
+    first = run_abc_round2_study(output_root=tmp_path / "one", **kwargs)
+    second = run_abc_round2_study(output_root=tmp_path / "two", **kwargs)
+
+    assert first["run_id"] == second["run_id"]
+    first_dir = Path(first["run_dir"])
+    second_dir = Path(second["run_dir"])
+    assert {path.name: path.read_bytes() for path in first_dir.iterdir()} == {
+        path.name: path.read_bytes() for path in second_dir.iterdir()
+    }
+
+    with pytest.raises(FileExistsError, match="immutable run already exists"):
+        run_abc_round2_study(output_root=tmp_path / "one", **kwargs)
+    assert not list((tmp_path / "one").glob(f".{first['run_id']}*"))

--- a/projects/quant-research-platform/tests/test_abc_round2_validation.py
+++ b/projects/quant-research-platform/tests/test_abc_round2_validation.py
@@ -40,14 +40,14 @@ def test_four_year_blocks_use_exact_calendar_boundaries_and_drop_trailing_block(
     blocks = non_overlapping_four_year_blocks(index)
 
     assert blocks == [
-        (pd.Timestamp("2011-01-01"), pd.Timestamp("2014-12-31")),
-        (pd.Timestamp("2015-01-01"), pd.Timestamp("2018-12-31")),
-        (pd.Timestamp("2019-01-01"), pd.Timestamp("2022-12-31")),
+        (pd.Timestamp("2012-01-01"), pd.Timestamp("2015-12-31")),
+        (pd.Timestamp("2016-01-01"), pd.Timestamp("2019-12-31")),
+        (pd.Timestamp("2020-01-01"), pd.Timestamp("2023-12-31")),
     ]
 
 
 def test_four_year_blocks_include_a_final_block_ending_with_the_calendar_year():
-    index = pd.bdate_range("2012-06-01", "2023-12-29")
+    index = pd.bdate_range("2012-01-02", "2023-12-29")
 
     blocks = non_overlapping_four_year_blocks(index)
 
@@ -56,7 +56,7 @@ def test_four_year_blocks_include_a_final_block_ending_with_the_calendar_year():
 
 
 def test_four_year_blocks_exclude_a_final_block_before_the_last_business_day():
-    index = pd.bdate_range("2012-06-01", "2023-12-28")
+    index = pd.bdate_range("2012-01-02", "2023-12-28")
 
     blocks = non_overlapping_four_year_blocks(index)
 
@@ -99,8 +99,8 @@ def test_subperiod_stability_reports_compounded_relative_log_rows_and_passes():
     assert summary["positive_fraction"] == pytest.approx(2 / 3)
     assert [row["pass"] for row in summary["blocks"]] == [True, True, False]
     first = summary["blocks"][0]
-    candidate_factor = (1.0 + candidate_returns.loc["2011":"2014"]).prod()
-    constant_factor = (1.0 + constant_returns.loc["2011":"2014"]).prod()
+    candidate_factor = (1.0 + candidate_returns.loc["2012":"2015"]).prod()
+    constant_factor = (1.0 + constant_returns.loc["2012":"2015"]).prod()
     assert first["candidate_compounded_return"] == pytest.approx(candidate_factor - 1.0)
     assert first["constant_compounded_return"] == pytest.approx(constant_factor - 1.0)
     assert first["relative_log_return"] == pytest.approx(
@@ -213,7 +213,71 @@ def test_circular_shift_timing_test_accepts_fractional_exposure():
         min_shift=60,
     )
 
+    assert result["requested_samples"] == 10
     assert result["samples"] == 10
+    assert result["evaluated_samples"] == 10
+    assert result["distinct_shift_count"] == 10
+
+
+def test_circular_shift_timing_test_evaluates_the_only_allowed_shift_once():
+    index = pd.bdate_range("2024-01-02", periods=120)
+    signal = pd.Series(np.r_[np.ones(60), np.zeros(60)], index=index)
+    forward_returns = np.r_[np.full(60, 0.01), np.full(59, -0.01)]
+    prices = pd.Series(
+        np.r_[100.0, 100.0 * np.cumprod(1.0 + forward_returns)],
+        index=index,
+    )
+
+    result = circular_shift_timing_test(
+        prices,
+        signal,
+        buy_cost_bps=0,
+        sell_cost_bps=0,
+        samples=1_000,
+        min_shift=60,
+        seed=17,
+        family_size=4,
+    )
+
+    assert result["requested_samples"] == 1_000
+    assert result["samples"] == 1
+    assert result["evaluated_samples"] == 1
+    assert result["distinct_shift_count"] == 1
+    assert result["random_cagr_q95"] < result["actual_cagr"]
+    assert result["raw_p_value"] == 0.5
+    assert result["bonferroni_p_value"] == 1.0
+
+
+def test_circular_shift_timing_test_rejects_invalid_actual_net_returns():
+    index = pd.bdate_range("2024-01-02", periods=120)
+    prices = pd.Series(100.0, index=index)
+    signal = pd.Series(np.r_[np.ones(60), np.zeros(60)], index=index)
+
+    with pytest.raises(ValueError, match="net returns.*greater than negative one"):
+        circular_shift_timing_test(
+            prices,
+            signal,
+            buy_cost_bps=10_000,
+            sell_cost_bps=0,
+            samples=1,
+            min_shift=60,
+        )
+
+
+def test_circular_shift_timing_test_rejects_invalid_randomized_net_returns():
+    index = pd.bdate_range("2024-01-02", periods=120)
+    prices = pd.Series(100.0, index=index)
+    signal = pd.Series(np.r_[np.zeros(60), np.ones(60)], index=index)
+
+    with pytest.raises(ValueError, match="randomized net returns.*greater than negative one"):
+        circular_shift_timing_test(
+            prices,
+            signal,
+            buy_cost_bps=0,
+            sell_cost_bps=10_000,
+            samples=1,
+            min_shift=60,
+        )
 
 
 @pytest.mark.parametrize(
@@ -313,6 +377,25 @@ def test_risk_utility_pass_implements_either_declared_branch_exactly():
     assert not risk_utility_pass(weak, buy_hold)
 
 
+@pytest.mark.parametrize(
+    ("side", "invalid_drawdown"),
+    [
+        ("candidate", 0.01),
+        ("candidate", -1.01),
+        ("buy_hold", 0.01),
+        ("buy_hold", -1.01),
+    ],
+)
+def test_risk_utility_pass_rejects_drawdowns_outside_financial_bounds(side, invalid_drawdown):
+    candidate = _metric_set(sharpe=1.1, max_drawdown=-0.30, calmar=0.40)
+    buy_hold = _metric_set(sharpe=1.0, max_drawdown=-0.40, calmar=0.20)
+    metrics = candidate if side == "candidate" else buy_hold
+    metrics["max_drawdown"] = invalid_drawdown
+
+    with pytest.raises(ValueError, match="maximum drawdowns.*between negative one and zero"):
+        risk_utility_pass(candidate, buy_hold)
+
+
 def _passing_gate_inputs() -> dict[str, object]:
     return {
         "target_base_metrics": _metric_set(),
@@ -382,4 +465,33 @@ def test_candidate_gate_decision_is_insufficient_when_no_gate_fails():
 
     assert decision["gates"][5]["status"] == "INSUFFICIENT"
     assert decision["gates"][7]["status"] == "INSUFFICIENT"
+    assert decision["overall"] == "INSUFFICIENT_EVIDENCE"
+
+
+@pytest.mark.parametrize("side", ["target_base_metrics", "target_buy_hold"])
+def test_candidate_gate_decision_is_insufficient_for_invalid_drawdown(side):
+    inputs = _passing_gate_inputs()
+    metrics = inputs[side]
+    assert isinstance(metrics, dict)
+    metrics["max_drawdown"] = 0.01
+    target_base = inputs["target_base_metrics"]
+    assert isinstance(target_base, dict)
+    target_base["calmar"] = 0.40
+
+    decision = candidate_gate_decision(**inputs)
+
+    assert decision["gates"][3]["status"] == "INSUFFICIENT"
+    assert decision["overall"] == "INSUFFICIENT_EVIDENCE"
+
+
+@pytest.mark.parametrize("invalid_p_value", [-0.01, 1.01])
+def test_candidate_gate_decision_is_insufficient_for_out_of_range_timing_p_value(
+    invalid_p_value,
+):
+    inputs = _passing_gate_inputs()
+    inputs["timing_result"] = {"bonferroni_p_value": invalid_p_value}
+
+    decision = candidate_gate_decision(**inputs)
+
+    assert decision["gates"][4]["status"] == "INSUFFICIENT"
     assert decision["overall"] == "INSUFFICIENT_EVIDENCE"

--- a/projects/quant-research-platform/tests/test_abc_round2_validation.py
+++ b/projects/quant-research-platform/tests/test_abc_round2_validation.py
@@ -1,0 +1,385 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from gold_research.abc_round2_validation import (
+    constant_exposure_signal,
+    circular_shift_timing_test,
+    candidate_gate_decision,
+    non_overlapping_four_year_blocks,
+    risk_utility_pass,
+    subperiod_stability,
+)
+
+
+def test_constant_exposure_signal_matches_scored_mean_and_preserves_index():
+    index = pd.bdate_range("2024-01-02", periods=4)
+    candidate = pd.Series([0.0, 1.0, 0.5, 0.5], index=index, name="candidate")
+
+    result = constant_exposure_signal(candidate)
+
+    pd.testing.assert_index_equal(result.index, index)
+    assert result.name == "constant_exposure_matched"
+    assert result.tolist() == [0.5, 0.5, 0.5, 0.5]
+
+
+@pytest.mark.parametrize(
+    "values",
+    ([0.0, np.nan], [0.0, np.inf], [-0.01, 0.5], [0.5, 1.01]),
+)
+def test_constant_exposure_signal_rejects_invalid_values(values):
+    signal = pd.Series(values, index=pd.bdate_range("2024-01-02", periods=len(values)))
+
+    with pytest.raises(ValueError, match="finite.*between zero and one"):
+        constant_exposure_signal(signal)
+
+
+def test_four_year_blocks_use_exact_calendar_boundaries_and_drop_trailing_block():
+    index = pd.bdate_range("2011-08-15", "2026-08-20")
+
+    blocks = non_overlapping_four_year_blocks(index)
+
+    assert blocks == [
+        (pd.Timestamp("2011-01-01"), pd.Timestamp("2014-12-31")),
+        (pd.Timestamp("2015-01-01"), pd.Timestamp("2018-12-31")),
+        (pd.Timestamp("2019-01-01"), pd.Timestamp("2022-12-31")),
+    ]
+
+
+def test_four_year_blocks_include_a_final_block_ending_with_the_calendar_year():
+    index = pd.bdate_range("2012-06-01", "2023-12-29")
+
+    blocks = non_overlapping_four_year_blocks(index)
+
+    assert blocks[-1] == (pd.Timestamp("2020-01-01"), pd.Timestamp("2023-12-31"))
+    assert len(blocks) == 3
+
+
+def test_four_year_blocks_exclude_a_final_block_before_the_last_business_day():
+    index = pd.bdate_range("2012-06-01", "2023-12-28")
+
+    blocks = non_overlapping_four_year_blocks(index)
+
+    assert blocks[-1] == (pd.Timestamp("2016-01-01"), pd.Timestamp("2019-12-31"))
+    assert len(blocks) == 2
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.Index([1, 2]),
+        pd.DatetimeIndex(["2024-01-02", "2024-01-02"]),
+        pd.DatetimeIndex(["2024-01-03", "2024-01-02"]),
+    ],
+)
+def test_four_year_blocks_require_a_unique_sorted_datetime_index(index):
+    with pytest.raises(ValueError, match="DatetimeIndex.*unique.*sorted"):
+        non_overlapping_four_year_blocks(index)
+
+
+def _result_from_returns(returns: pd.Series) -> pd.DataFrame:
+    return pd.DataFrame({"net_return": returns}, index=returns.index)
+
+
+def test_subperiod_stability_reports_compounded_relative_log_rows_and_passes():
+    index = pd.bdate_range("2011-07-01", "2023-12-29")
+    constant_returns = pd.Series(0.0001, index=index)
+    candidate_returns = constant_returns.copy()
+    candidate_returns.loc[candidate_returns.index.year <= 2018] = 0.0002
+    candidate_returns.loc[candidate_returns.index.year >= 2019] = 0.0
+
+    summary = subperiod_stability(
+        _result_from_returns(candidate_returns),
+        _result_from_returns(constant_returns),
+    )
+
+    assert summary["status"] == "PASS"
+    assert summary["complete_blocks"] == 3
+    assert summary["positive_relative_log_blocks"] == 2
+    assert summary["positive_fraction"] == pytest.approx(2 / 3)
+    assert [row["pass"] for row in summary["blocks"]] == [True, True, False]
+    first = summary["blocks"][0]
+    candidate_factor = (1.0 + candidate_returns.loc["2011":"2014"]).prod()
+    constant_factor = (1.0 + constant_returns.loc["2011":"2014"]).prod()
+    assert first["candidate_compounded_return"] == pytest.approx(candidate_factor - 1.0)
+    assert first["constant_compounded_return"] == pytest.approx(constant_factor - 1.0)
+    assert first["relative_log_return"] == pytest.approx(
+        np.log(candidate_factor) - np.log(constant_factor)
+    )
+
+
+def test_subperiod_stability_is_insufficient_with_fewer_than_three_complete_blocks():
+    index = pd.bdate_range("2017-02-01", "2026-08-20")
+    candidate = _result_from_returns(pd.Series(0.001, index=index))
+    constant = _result_from_returns(pd.Series(0.0, index=index))
+
+    summary = subperiod_stability(candidate, constant)
+
+    assert summary["complete_blocks"] == 2
+    assert summary["status"] == "INSUFFICIENT"
+
+
+def test_subperiod_stability_fails_when_fewer_than_sixty_percent_are_positive():
+    index = pd.bdate_range("2008-01-02", "2019-12-31")
+    constant_returns = pd.Series(0.0, index=index)
+    candidate_returns = pd.Series(0.001, index=index)
+    candidate_returns.loc[candidate_returns.index.year >= 2012] = -0.001
+
+    summary = subperiod_stability(
+        _result_from_returns(candidate_returns),
+        _result_from_returns(constant_returns),
+    )
+
+    assert summary["positive_relative_log_blocks"] == 1
+    assert summary["positive_fraction"] == pytest.approx(1 / 3)
+    assert summary["status"] == "FAIL"
+
+
+def _genuinely_timed_path() -> tuple[pd.Series, pd.Series]:
+    rng = np.random.default_rng(42)
+    index = pd.bdate_range("2018-01-02", periods=900)
+    signal = pd.Series(rng.integers(0, 2, len(index)).astype(float), index=index)
+    forward_returns = np.where(signal.to_numpy()[:-1] > 0.0, 0.003, -0.003)
+    prices = np.r_[100.0, 100.0 * np.cumprod(1.0 + forward_returns)]
+    return pd.Series(prices, index=index, name="Open"), signal
+
+
+def test_circular_shift_timing_test_detects_a_genuinely_timed_signal():
+    prices, signal = _genuinely_timed_path()
+
+    result = circular_shift_timing_test(
+        prices,
+        signal,
+        buy_cost_bps=8,
+        sell_cost_bps=13,
+        samples=999,
+        min_shift=60,
+        seed=17,
+        family_size=4,
+    )
+
+    assert result["actual_cagr"] > result["random_cagr_q95"]
+    assert result["raw_p_value"] <= 0.01
+    assert result["bonferroni_p_value"] <= 0.05
+    assert result["random_cagr_q05"] <= result["random_cagr_median"]
+    assert result["random_cagr_median"] <= result["random_cagr_q95"]
+
+
+def test_circular_shift_timing_test_is_deterministic_for_a_seed():
+    prices, signal = _genuinely_timed_path()
+    kwargs = {
+        "buy_cost_bps": 8,
+        "sell_cost_bps": 13,
+        "samples": 200,
+        "min_shift": 60,
+        "seed": 20260820,
+        "family_size": 4,
+    }
+
+    first = circular_shift_timing_test(prices, signal, **kwargs)
+    second = circular_shift_timing_test(prices, signal, **kwargs)
+
+    assert first == second
+
+
+def test_circular_shift_timing_test_applies_bonferroni_correction():
+    prices, signal = _genuinely_timed_path()
+
+    result = circular_shift_timing_test(
+        prices,
+        signal,
+        buy_cost_bps=0,
+        sell_cost_bps=0,
+        samples=100,
+        min_shift=60,
+        seed=5,
+        family_size=4,
+    )
+
+    assert result["bonferroni_p_value"] == pytest.approx(min(1.0, 4.0 * result["raw_p_value"]))
+
+
+def test_circular_shift_timing_test_accepts_fractional_exposure():
+    index = pd.bdate_range("2020-01-02", periods=160)
+    prices = pd.Series(np.linspace(100.0, 120.0, len(index)), index=index)
+    signal = pd.Series(np.tile([0.0, 0.25, 0.75, 1.0], 40), index=index)
+
+    result = circular_shift_timing_test(
+        prices,
+        signal,
+        buy_cost_bps=8,
+        sell_cost_bps=13,
+        samples=10,
+        min_shift=60,
+    )
+
+    assert result["samples"] == 10
+
+
+@pytest.mark.parametrize(
+    ("mutator", "error"),
+    [
+        (lambda prices, signal: (prices.iloc[:-1], signal), "indexes must match"),
+        (
+            lambda prices, signal: (prices.mask(prices.index == prices.index[0], 0.0), signal),
+            "prices",
+        ),
+        (
+            lambda prices, signal: (prices, signal.mask(signal.index == signal.index[0], np.nan)),
+            "signal",
+        ),
+        (lambda prices, signal: (prices, signal + 0.01), "signal"),
+    ],
+)
+def test_circular_shift_timing_test_rejects_invalid_paths(mutator, error):
+    index = pd.bdate_range("2024-01-02", periods=160)
+    prices = pd.Series(np.linspace(100.0, 110.0, len(index)), index=index)
+    signal = pd.Series(np.tile([0.0, 1.0], 80), index=index)
+    invalid_prices, invalid_signal = mutator(prices, signal)
+
+    with pytest.raises(ValueError, match=error):
+        circular_shift_timing_test(
+            invalid_prices,
+            invalid_signal,
+            buy_cost_bps=8,
+            sell_cost_bps=13,
+            samples=10,
+            min_shift=60,
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        ({"buy_cost_bps": -1}, "cost"),
+        ({"sell_cost_bps": np.inf}, "cost"),
+        ({"samples": 0}, "samples"),
+        ({"min_shift": 0}, "min_shift"),
+        ({"family_size": 0}, "family_size"),
+    ],
+)
+def test_circular_shift_timing_test_rejects_invalid_parameters(overrides, error):
+    index = pd.bdate_range("2024-01-02", periods=160)
+    prices = pd.Series(np.linspace(100.0, 110.0, len(index)), index=index)
+    signal = pd.Series(np.tile([0.0, 1.0], 80), index=index)
+    kwargs = {
+        "buy_cost_bps": 8,
+        "sell_cost_bps": 13,
+        "samples": 10,
+        "min_shift": 60,
+        "family_size": 4,
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=error):
+        circular_shift_timing_test(prices, signal, **kwargs)
+
+
+def test_circular_shift_timing_test_requires_enough_rows_for_allowed_shifts():
+    index = pd.bdate_range("2024-01-02", periods=119)
+    prices = pd.Series(np.linspace(100.0, 110.0, len(index)), index=index)
+    signal = pd.Series(np.tile([0.0, 1.0], 60)[: len(index)], index=index)
+
+    with pytest.raises(ValueError, match="enough rows"):
+        circular_shift_timing_test(
+            prices,
+            signal,
+            buy_cost_bps=8,
+            sell_cost_bps=13,
+            samples=10,
+            min_shift=60,
+        )
+
+
+def _metric_set(
+    *, cagr: float = 0.08, sharpe: float = 1.1, max_drawdown: float = -0.30, calmar: float = 0.3
+) -> dict[str, float]:
+    return {
+        "cagr": cagr,
+        "sharpe": sharpe,
+        "max_drawdown": max_drawdown,
+        "calmar": calmar,
+    }
+
+
+def test_risk_utility_pass_implements_either_declared_branch_exactly():
+    buy_hold = _metric_set(sharpe=1.0, max_drawdown=-0.40, calmar=0.30)
+    drawdown_branch = _metric_set(sharpe=1.01, max_drawdown=-0.34, calmar=0.20)
+    calmar_branch = _metric_set(sharpe=0.8, max_drawdown=-0.50, calmar=0.40)
+    weak = _metric_set(sharpe=1.0, max_drawdown=-0.34, calmar=0.399)
+
+    assert risk_utility_pass(drawdown_branch, buy_hold)
+    assert risk_utility_pass(calmar_branch, buy_hold)
+    assert not risk_utility_pass(weak, buy_hold)
+
+
+def _passing_gate_inputs() -> dict[str, object]:
+    return {
+        "target_base_metrics": _metric_set(),
+        "target_stress_metrics": _metric_set(cagr=0.04, sharpe=0.5),
+        "target_buy_hold": _metric_set(cagr=0.10, sharpe=1.0, max_drawdown=-0.40, calmar=0.20),
+        "constant_benchmark": _metric_set(cagr=0.07),
+        "timing_result": {"bonferroni_p_value": 0.04},
+        "stability_summary": {"status": "PASS"},
+        "peer_sharpe_wins_count": 4,
+        "execution_complete": True,
+    }
+
+
+def test_candidate_gate_decision_emits_all_eight_gates_in_frozen_order():
+    decision = candidate_gate_decision(**_passing_gate_inputs())
+
+    assert [gate["id"] for gate in decision["gates"]] == [
+        "positive_base_cagr_and_sharpe",
+        "positive_stress_cagr_and_sharpe",
+        "target_cagr_at_least_70pct_buy_hold",
+        "risk_utility_improvement",
+        "beats_constant_exposure_and_familywise_random_timing_p_le_0_05",
+        "stable_across_predeclared_subperiods",
+        "improves_risk_adjusted_objective_on_at_least_4_of_6_peers",
+        "executable_data_and_cost_model_complete",
+    ]
+    assert [gate["status"] for gate in decision["gates"]] == ["PASS"] * 8
+    assert decision["overall"] == "HISTORICALLY_SUPPORTED_FOR_PAPER_FORWARD"
+
+
+def test_all_weak_candidate_family_is_rejected_without_a_forced_winner():
+    weak_inputs = _passing_gate_inputs()
+    weak_inputs.update(
+        {
+            "target_base_metrics": _metric_set(cagr=-0.01, sharpe=-0.2, calmar=-0.1),
+            "target_stress_metrics": _metric_set(cagr=-0.02, sharpe=-0.3, calmar=-0.2),
+            "constant_benchmark": _metric_set(cagr=0.02),
+            "timing_result": {"bonferroni_p_value": 0.8},
+            "stability_summary": {"status": "FAIL"},
+            "peer_sharpe_wins_count": 0,
+        }
+    )
+
+    family = [candidate_gate_decision(**weak_inputs) for _ in range(4)]
+
+    assert [candidate["overall"] for candidate in family] == ["REJECTED_NO_EDGE"] * 4
+    assert all(any(gate["status"] == "FAIL" for gate in candidate["gates"]) for candidate in family)
+
+
+def test_candidate_gate_decision_prefers_fail_over_insufficient():
+    inputs = _passing_gate_inputs()
+    inputs["target_base_metrics"] = _metric_set(cagr=-0.01)
+    inputs["stability_summary"] = {"status": "INSUFFICIENT"}
+    inputs["execution_complete"] = None
+
+    decision = candidate_gate_decision(**inputs)
+
+    assert decision["overall"] == "REJECTED_NO_EDGE"
+
+
+def test_candidate_gate_decision_is_insufficient_when_no_gate_fails():
+    inputs = _passing_gate_inputs()
+    inputs["stability_summary"] = {"status": "INSUFFICIENT"}
+    inputs["execution_complete"] = None
+
+    decision = candidate_gate_decision(**inputs)
+
+    assert decision["gates"][5]["status"] == "INSUFFICIENT"
+    assert decision["gates"][7]["status"] == "INSUFFICIENT"
+    assert decision["overall"] == "INSUFFICIENT_EVIDENCE"

--- a/projects/quant-research-platform/tests/test_backtest.py
+++ b/projects/quant-research-platform/tests/test_backtest.py
@@ -19,6 +19,31 @@ def test_costs_are_reported_before_and_after_and_reduce_return():
     assert result["cost"].sum() > 0
 
 
+def test_asymmetric_costs_charge_buy_and_sell_turnover_separately():
+    index = pd.bdate_range("2024-01-02", periods=5)
+    opens = pd.Series([100.0, 101.0, 102.0, 103.0, 104.0], index=index)
+    signal = pd.Series([0.0, 1.0, 1.0, 0.0, 0.0], index=index)
+    result = backtest(opens, signal, buy_cost_bps=8.0, sell_cost_bps=13.0)
+    assert result["buy_turnover"].sum() == pytest.approx(1.0)
+    assert result["sell_turnover"].sum() == pytest.approx(1.0)
+    assert result["cost"].sum() == pytest.approx(0.0021)
+
+
+@pytest.mark.parametrize(
+    ("buy_cost_bps", "sell_cost_bps"),
+    [(-1.0, 5.0), (5.0, -1.0), (np.nan, 5.0), (5.0, np.inf), (True, 5.0)],
+)
+def test_backtest_rejects_invalid_asymmetric_costs(buy_cost_bps, sell_cost_bps):
+    p = sample(10)
+    with pytest.raises(ValueError, match="cost"):
+        backtest(
+            p,
+            pd.Series(1.0, index=p.index),
+            buy_cost_bps=buy_cost_bps,
+            sell_cost_bps=sell_cost_bps,
+        )
+
+
 def test_trade_ledger_uses_attainable_next_open_execution():
     from gold_research.backtest import trade_ledger
 

--- a/projects/quant-research-platform/tests/test_run.py
+++ b/projects/quant-research-platform/tests/test_run.py
@@ -24,6 +24,18 @@ def test_data_hash_covers_all_present_canonical_input_columns():
     assert _data_hash(left) != _data_hash(right)
 
 
+def test_data_hash_distinguishes_every_behaviorally_relevant_float64_value():
+    idx = pd.bdate_range("2024-01-01", periods=2)
+    left = {"ABC": pd.DataFrame({"Open": [100.0, 101.0], "Close": [100.0, 101.0]}, index=idx)}
+    right = {
+        "ABC": pd.DataFrame(
+            {"Open": [100.0, 101.0], "Close": [100.000000001, 101.0]},
+            index=idx,
+        )
+    }
+    assert _data_hash(left) != _data_hash(right)
+
+
 def test_source_tree_hash_changes_with_effective_source(tmp_path):
     (tmp_path / "src").mkdir()
     source = tmp_path / "src" / "strategy.py"


### PR DESCRIPTION
## Summary

- add four frozen Agricultural Bank trend candidates with exact next-open timing
- add no-forced-winner validation gates, exposure-matched benchmarks, exact circular-shift timing tests, four-year stability checks, and six-bank peer replication
- add an immutable seven-symbol evidence runner with manifest/protocol/Git provenance
- fix the prior workflow so an all-weak candidate family is rejected instead of forced to produce a winner

## Research result

Canonical clean run: `6cec1e3b3bee73e4`

- all four candidates: `REJECTED_NO_EDGE`
- buy-and-hold CAGR: 12.35%, Sharpe: 0.71, max drawdown: -29.11%
- highest candidate CAGR: monthly 12-month momentum at 9.97%, but it failed risk utility, random-timing, subperiod, peer, and execution-completeness gates
- peer Sharpe improvements: 0/6 for every candidate
- exact distinct circular shifts evaluated: 3,474 per candidate

## Verification

- 176 tests passed
- Ruff check and format passed
- Gitleaks pre-commit hooks passed
- independent quant/provenance audit: PASS
- complete bar cutoff: 2026-08-19; same-day partial Yahoo bar excluded

## Boundaries

Research only. No broker integration or live order path. Static cost scenarios remain optimistic comparability tests; the execution-completeness gate fails closed.

Closes #136
